### PR TITLE
Maximum magnitude earthquake and coordinates

### DIFF
--- a/week04/quakes.py
+++ b/week04/quakes.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
 
     quakes = requests.get("http://earthquake.usgs.gov/fdsnws/event/1/query.geojson",
                       params={
-                          'starttime': "2000-01-01",
+                          'starttime': "1900-01-01", 
                           "maxlatitude": "58.723",
                           "minlatitude": "50.008",
                           "maxlongitude": "1.67",

--- a/week04/quakes.py
+++ b/week04/quakes.py
@@ -1,17 +1,31 @@
 """A script to find the biggest earthquake in an online dataset."""
+import json
+import requests
 
-# At the top of the file, import any libraries you will use.
-# import ...
-
-# If you want, you can define some functions to help organise your code.
-# def helper_function(argument_1, argument_2):
-#   ...
-
-# When you run the file, it should print out the location and magnitude
-# of the biggest earthquake.
-# You can run the file with `python quakes.py` from this directory.
 if __name__ == "__main__":
-    # ...do things here to find the results...
+
+    quakes = requests.get("http://earthquake.usgs.gov/fdsnws/event/1/query.geojson",
+                      params={
+                          'starttime': "2000-01-01",
+                          "maxlatitude": "58.723",
+                          "minlatitude": "50.008",
+                          "maxlongitude": "1.67",
+                          "minlongitude": "-9.756",
+                          "minmagnitude": "1",
+                          "endtime": "2018-10-11",
+                          "orderby": "time-asc"}
+                      )
+    print(quakes.text[0:100])
+
+    # Save request in json file for exploration
+    json_data = json.loads(quakes.text)
+    with open("quakes.txt", "w") as f:
+        json.dump(json_data,f, indent = 4)
+
+
+    quake_data = json_data['features']
+    max_magnitude = max([quake['properties']['mag'] for quake in quake_data])
+    coords = [quake['geometry']['coordinates'] for quake in quake_data if quake['properties']['mag'] == max_magnitude]
 
     # The lines below assume that the results are stored in variables
     # named max_magnitude and coords, but you can change that.

--- a/week04/quakes.txt
+++ b/week04/quakes.txt
@@ -1,0 +1,4821 @@
+{
+    "type": "FeatureCollection",
+    "metadata": {
+        "generated": 1603660656000,
+        "url": "https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?starttime=2000-01-01&maxlatitude=58.723&minlatitude=50.008&maxlongitude=1.67&minlongitude=-9.756&minmagnitude=1&endtime=2018-10-11&orderby=time-asc",
+        "title": "USGS Earthquakes",
+        "status": 200,
+        "api": "1.10.3",
+        "count": 120
+    },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 956553055700,
+                "updated": 1415322596133,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009rst",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009rst&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p0009rst",
+                "ids": ",usp0009rst,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.81,
+                    54.77,
+                    14
+                ]
+            },
+            "id": "usp0009rst"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4,
+                "place": "England, United Kingdom",
+                "time": 969683025790,
+                "updated": 1415322666913,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000a0pm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000a0pm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 246,
+                "net": "us",
+                "code": "p000a0pm",
+                "ids": ",usp000a0pm,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 55,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.61,
+                    52.28,
+                    13.1
+                ]
+            },
+            "id": "usp000a0pm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4,
+                "place": "North Sea",
+                "time": 977442788510,
+                "updated": 1415322705662,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000a6hd",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000a6hd&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 246,
+                "net": "us",
+                "code": "p000a6hd",
+                "ids": ",usp000a6hd,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 27,
+                "dmin": null,
+                "rms": 1.12,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.0 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.564,
+                    53.236,
+                    10
+                ]
+            },
+            "id": "usp000a6hd"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "North Sea",
+                "time": 984608438660,
+                "updated": 1415322741153,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000abdr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000abdr&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000abdr",
+                "ids": ",usp000abdr,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 36,
+                "dmin": null,
+                "rms": 1.44,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 3.3 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.872,
+                    58.097,
+                    10
+                ]
+            },
+            "id": "usp000abdr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 984879824720,
+                "updated": 1415322742102,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000abnc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000abnc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p000abnc",
+                "ids": ",usp000abnc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": 0.57,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.845,
+                    51.432,
+                    10
+                ]
+            },
+            "id": "usp000abnc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "Scotland, United Kingdom",
+                "time": 989742419300,
+                "updated": 1415322767519,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000aevu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000aevu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p000aevu",
+                "ids": ",usp000aevu,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 22,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.639,
+                    55.102,
+                    12.3
+                ]
+            },
+            "id": "usp000aevu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4,
+                "place": "England, United Kingdom",
+                "time": 991352577300,
+                "updated": 1415322772628,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000afuv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000afuv&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 246,
+                "net": "us",
+                "code": "p000afuv",
+                "ids": ",usp000afuv,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 59,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.684,
+                    50.995,
+                    28.7
+                ]
+            },
+            "id": "usp000afuv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 993662993990,
+                "updated": 1415322788547,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ahkb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ahkb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000ahkb",
+                "ids": ",usp000ahkb,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 17,
+                "dmin": null,
+                "rms": 0.99,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.144,
+                    51.76,
+                    10
+                ]
+            },
+            "id": "usp000ahkb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 993668185470,
+                "updated": 1415322788557,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ahkf",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ahkf&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000ahkf",
+                "ids": ",usp000ahkf,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": 0.75,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.094,
+                    51.332,
+                    10
+                ]
+            },
+            "id": "usp000ahkf"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1002682343130,
+                "updated": 1415322838210,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000aqku",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000aqku&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000aqku",
+                "ids": ",usp000aqku,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 38,
+                "dmin": null,
+                "rms": 1.04,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.205,
+                    51.552,
+                    10
+                ]
+            },
+            "id": "usp000aqku"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1003377013600,
+                "updated": 1415322840661,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ar5p",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ar5p&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000ar5p",
+                "ids": ",usp000ar5p,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 34,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.25,
+                    51.7,
+                    7.9
+                ]
+            },
+            "id": "usp000ar5p"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.2,
+                "place": "England, United Kingdom",
+                "time": 1004286325100,
+                "updated": 1415322844421,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000artg",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000artg&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 271,
+                "net": "us",
+                "code": "p000artg",
+                "ids": ",usp000artg,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 152,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.856,
+                    52.846,
+                    11.6
+                ]
+            },
+            "id": "usp000artg"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1012177812770,
+                "updated": 1415322885742,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000axaa",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000axaa&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000axaa",
+                "ids": ",usp000axaa,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 17,
+                "dmin": null,
+                "rms": 0.78,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.14,
+                    51.63,
+                    10
+                ]
+            },
+            "id": "usp000axaa"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "North Sea",
+                "time": 1012410365310,
+                "updated": 1415322886960,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000axff",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000axff&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p000axff",
+                "ids": ",usp000axff,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 34,
+                "dmin": null,
+                "rms": 0.91,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.288,
+                    53.168,
+                    10
+                ]
+            },
+            "id": "usp000axff"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1013541196400,
+                "updated": 1415322894547,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000aybb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000aybb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000aybb",
+                "ids": ",usp000aybb,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 32,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.255,
+                    51.7,
+                    8.3
+                ]
+            },
+            "id": "usp000aybb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1024594001800,
+                "updated": 1415322952043,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000b6kc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000b6kc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p000b6kc",
+                "ids": ",usp000b6kc,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 28,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.081,
+                    51.567,
+                    14.3
+                ]
+            },
+            "id": "usp000b6kc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 1030405284900,
+                "updated": 1415322980684,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000baq2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000baq2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000baq2",
+                "ids": ",usp000baq2,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.009,
+                    50.048,
+                    4
+                ]
+            },
+            "id": "usp000baq2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 1031136485700,
+                "updated": 1415322986488,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bb7y",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bb7y&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000bb7y",
+                "ids": ",usp000bb7y,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.749,
+                    56.596,
+                    7.6
+                ]
+            },
+            "id": "usp000bb7y"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Wales-England region, United Kingdom",
+                "time": 1032326410300,
+                "updated": 1415322992506,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bcjt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bcjt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p000bcjt",
+                "ids": ",usp000bcjt,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 11,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.588,
+                    51.713,
+                    1.5
+                ]
+            },
+            "id": "usp000bcjt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.8,
+                "place": "England, United Kingdom",
+                "time": 1032738794600,
+                "updated": 1600455819229,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bcxg",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bcxg&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": 6.161,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 354,
+                "net": "us",
+                "code": "p000bcxg",
+                "ids": ",usp000bcxg,atlas20020922235314,",
+                "sources": ",us,atlas,",
+                "types": ",impact-text,origin,phase-data,shakemap,trump-shakemap,",
+                "nst": 268,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.15,
+                    52.52,
+                    9.4
+                ]
+            },
+            "id": "usp000bcxg"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 1032751935900,
+                "updated": 1415322994003,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bcxx",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bcxx&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p000bcxx",
+                "ids": ",usp000bcxx,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 35,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.136,
+                    52.522,
+                    9.3
+                ]
+            },
+            "id": "usp000bcxx"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.2,
+                "place": "England, United Kingdom",
+                "time": 1032859759000,
+                "updated": 1415322994328,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bd0s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bd0s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 22,
+                "net": "us",
+                "code": "p000bd0s",
+                "ids": ",usp000bd0s,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.138,
+                    52.521,
+                    7.9
+                ]
+            },
+            "id": "usp000bd0s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 1035186315800,
+                "updated": 1415323007399,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000beyp",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000beyp&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p000beyp",
+                "ids": ",usp000beyp,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2,
+                    53.475,
+                    5
+                ]
+            },
+            "id": "usp000beyp"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "England, United Kingdom",
+                "time": 1035200554900,
+                "updated": 1415323007416,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000beyx",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000beyx&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 284,
+                "net": "us",
+                "code": "p000beyx",
+                "ids": ",usp000beyx,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 46,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.219,
+                    53.478,
+                    5
+                ]
+            },
+            "id": "usp000beyx"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 1035257977600,
+                "updated": 1415323007539,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf0a",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf0a&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p000bf0a",
+                "ids": ",usp000bf0a,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.219,
+                    53.463,
+                    5
+                ]
+            },
+            "id": "usp000bf0a"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "England, United Kingdom",
+                "time": 1035289688400,
+                "updated": 1415323007625,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf0s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf0s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000bf0s",
+                "ids": ",usp000bf0s,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.146,
+                    53.473,
+                    4.2
+                ]
+            },
+            "id": "usp000bf0s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 1035338008790,
+                "updated": 1415323007751,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf1x",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf1x&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000bf1x",
+                "ids": ",usp000bf1x,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 14,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.157,
+                    53.477,
+                    5
+                ]
+            },
+            "id": "usp000bf1x"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "England, United Kingdom",
+                "time": 1035447894700,
+                "updated": 1415323008575,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf7c",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf7c&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 222,
+                "net": "us",
+                "code": "p000bf7c",
+                "ids": ",usp000bf7c,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 23,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.179,
+                    53.485,
+                    3.7
+                ]
+            },
+            "id": "usp000bf7c"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "England, United Kingdom",
+                "time": 1035474404200,
+                "updated": 1415323008696,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf8p",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf8p&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p000bf8p",
+                "ids": ",usp000bf8p,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.197,
+                    53.482,
+                    5
+                ]
+            },
+            "id": "usp000bf8p"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 1035505167290,
+                "updated": 1415323008830,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf9v",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf9v&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000bf9v",
+                "ids": ",usp000bf9v,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 15,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.204,
+                    53.481,
+                    5
+                ]
+            },
+            "id": "usp000bf9v"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 1035505239700,
+                "updated": 1415323008832,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bf9w",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bf9w&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000bf9w",
+                "ids": ",usp000bf9w,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.213,
+                    53.488,
+                    5
+                ]
+            },
+            "id": "usp000bf9w"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 1035566688290,
+                "updated": 1415323009056,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bfbr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bfbr&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000bfbr",
+                "ids": ",usp000bfbr,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.188,
+                    53.477,
+                    5
+                ]
+            },
+            "id": "usp000bfbr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.1,
+                "place": "England, United Kingdom",
+                "time": 1035866572000,
+                "updated": 1415323010483,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bfjw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bfjw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 148,
+                "net": "us",
+                "code": "p000bfjw",
+                "ids": ",usp000bfjw,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 10,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.1 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.198,
+                    53.481,
+                    5
+                ]
+            },
+            "id": "usp000bfjw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 1051748450100,
+                "updated": 1415323109903,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000bwbb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000bwbb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000bwbb",
+                "ids": ",usp000bwbb,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 11,
+                "dmin": null,
+                "rms": null,
+                "gap": 242.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.582,
+                    51.055,
+                    10
+                ]
+            },
+            "id": "usp000bwbb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Scotland, United Kingdom",
+                "time": 1056091459700,
+                "updated": 1415323137863,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000c0ah",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000c0ah&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000c0ah",
+                "ids": ",usp000c0ah,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 287.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.416,
+                    56.169,
+                    5
+                ]
+            },
+            "id": "usp000c0ah"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Scotland, United Kingdom",
+                "time": 1056092004600,
+                "updated": 1415323137869,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000c0ak",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000c0ak&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p000c0ak",
+                "ids": ",usp000c0ak,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 287.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.439,
+                    56.181,
+                    5.4
+                ]
+            },
+            "id": "usp000c0ak"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 1056099807390,
+                "updated": 1415323137891,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000c0av",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000c0av&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000c0av",
+                "ids": ",usp000c0av,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 287.3,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.427,
+                    56.167,
+                    4.3
+                ]
+            },
+            "id": "usp000c0av"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 1061322378600,
+                "updated": 1415323173139,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000c5cm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000c5cm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p000c5cm",
+                "ids": ",usp000c5cm,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 31,
+                "dmin": null,
+                "rms": null,
+                "gap": 164.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.013,
+                    53.481,
+                    13.2
+                ]
+            },
+            "id": "usp000c5cm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 1075373761600,
+                "updated": 1415323270187,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000cjxx",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000cjxx&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000cjxx",
+                "ids": ",usp000cjxx,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": null,
+                "gap": 132.6,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.98,
+                    51.089,
+                    6.5
+                ]
+            },
+            "id": "usp000cjxx"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "England, United Kingdom",
+                "time": 1075373813000,
+                "updated": 1415323270190,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000cjxy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000cjxy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p000cjxy",
+                "ids": ",usp000cjxy,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 34,
+                "dmin": null,
+                "rms": null,
+                "gap": 128.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.98,
+                    51.089,
+                    6.5
+                ]
+            },
+            "id": "usp000cjxy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 1075407815100,
+                "updated": 1415323270269,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000cjyu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000cjyu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p000cjyu",
+                "ids": ",usp000cjyu,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 40,
+                "dmin": null,
+                "rms": null,
+                "gap": 128.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.98,
+                    51.089,
+                    6.5
+                ]
+            },
+            "id": "usp000cjyu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 1078031285200,
+                "updated": 1415323292202,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000cnq3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000cnq3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p000cnq3",
+                "ids": ",usp000cnq3,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 48,
+                "dmin": null,
+                "rms": null,
+                "gap": 96,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.999,
+                    53.566,
+                    12.4
+                ]
+            },
+            "id": "usp000cnq3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "North Sea",
+                "time": 1082584411250,
+                "updated": 1415323323968,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ct2t",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ct2t&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000ct2t",
+                "ids": ",usp000ct2t,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 14,
+                "dmin": null,
+                "rms": 0.52,
+                "gap": 170.8,
+                "magType": "md",
+                "type": "earthquake",
+                "title": "M 2.7 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.765,
+                    58.146,
+                    10
+                ]
+            },
+            "id": "usp000ct2t"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 1089065851000,
+                "updated": 1415323371252,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000czmn",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000czmn&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000czmn",
+                "ids": ",usp000czmn,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 17,
+                "dmin": null,
+                "rms": null,
+                "gap": 183.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.602,
+                    53.936,
+                    9.5
+                ]
+            },
+            "id": "usp000czmn"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "United Kingdom",
+                "time": 1108406640800,
+                "updated": 1415323499654,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000dg4z",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000dg4z&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 222,
+                "net": "us",
+                "code": "p000dg4z",
+                "ids": ",usp000dg4z,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 51,
+                "dmin": null,
+                "rms": null,
+                "gap": 94.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.853,
+                    53.265,
+                    4.9
+                ]
+            },
+            "id": "usp000dg4z"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 1118193681160,
+                "updated": 1415323569348,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000dsg6",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000dsg6&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000dsg6",
+                "ids": ",usp000dsg6,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": 0.56,
+                "gap": 146.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.055,
+                    53.092,
+                    5
+                ]
+            },
+            "id": "usp000dsg6"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 1121538549200,
+                "updated": 1415323590312,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000dvbc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000dvbc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p000dvbc",
+                "ids": ",usp000dvbc,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 18,
+                "dmin": null,
+                "rms": null,
+                "gap": 247.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.392,
+                    51.008,
+                    5
+                ]
+            },
+            "id": "usp000dvbc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Scotland, United Kingdom",
+                "time": 1134256889900,
+                "updated": 1415323672530,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e5y4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e5y4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000e5y4",
+                "ids": ",usp000e5y4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 13,
+                "dmin": null,
+                "rms": null,
+                "gap": 112.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.224,
+                    56.839,
+                    7.5
+                ]
+            },
+            "id": "usp000e5y4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "England, United Kingdom",
+                "time": 1134280891200,
+                "updated": 1415323672638,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e5ym",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e5ym&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p000e5ym",
+                "ids": ",usp000e5ym,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 21,
+                "dmin": null,
+                "rms": null,
+                "gap": 70.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.395,
+                    51.772,
+                    0
+                ]
+            },
+            "id": "usp000e5ym"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "Irish Sea",
+                "time": 1134531025500,
+                "updated": 1415323673479,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e63y",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e63y&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p000e63y",
+                "ids": ",usp000e63y,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 48,
+                "dmin": null,
+                "rms": null,
+                "gap": 89.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - Irish Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.641,
+                    53.001,
+                    10
+                ]
+            },
+            "id": "usp000e63y"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Scotland, United Kingdom",
+                "time": 1135308351100,
+                "updated": 1415323675863,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e6ns",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e6ns&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000e6ns",
+                "ids": ",usp000e6ns,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 12,
+                "dmin": null,
+                "rms": null,
+                "gap": 136.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.685,
+                    56.68,
+                    6.7
+                ]
+            },
+            "id": "usp000e6ns"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "Scotland, United Kingdom",
+                "time": 1135313901600,
+                "updated": 1415323675871,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e6nw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e6nw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p000e6nw",
+                "ids": ",usp000e6nw,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 11,
+                "dmin": null,
+                "rms": null,
+                "gap": 135.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.662,
+                    56.668,
+                    7.5
+                ]
+            },
+            "id": "usp000e6nw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Scotland, United Kingdom",
+                "time": 1135831229210,
+                "updated": 1415323677960,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e74q",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e74q&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p000e74q",
+                "ids": ",usp000e74q,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 6,
+                "dmin": null,
+                "rms": 0.06,
+                "gap": 124.9,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.736,
+                    56.245,
+                    10.8
+                ]
+            },
+            "id": "usp000e74q"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 1136068805700,
+                "updated": 1415323678586,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e7ag",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e7ag&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000e7ag",
+                "ids": ",usp000e7ag,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 11,
+                "dmin": null,
+                "rms": null,
+                "gap": 135.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.761,
+                    56.277,
+                    5.9
+                ]
+            },
+            "id": "usp000e7ag"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 1137092632000,
+                "updated": 1415323685963,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000e83s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000e83s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000e83s",
+                "ids": ",usp000e83s,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 27,
+                "dmin": null,
+                "rms": null,
+                "gap": 117.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.22,
+                    51.31,
+                    15
+                ]
+            },
+            "id": "usp000e83s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "Scotland, United Kingdom",
+                "time": 1145497550700,
+                "updated": 1415323732307,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000eeyt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000eeyt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p000eeyt",
+                "ids": ",usp000eeyt,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 15,
+                "dmin": null,
+                "rms": null,
+                "gap": 117.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.233,
+                    56.676,
+                    7.5
+                ]
+            },
+            "id": "usp000eeyt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "Scotland, United Kingdom",
+                "time": 1149769428100,
+                "updated": 1415323760381,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ejy2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ejy2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p000ejy2",
+                "ids": ",usp000ejy2,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 22,
+                "dmin": null,
+                "rms": null,
+                "gap": 74.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.642,
+                    57.531,
+                    8.3
+                ]
+            },
+            "id": "usp000ejy2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 1155573645460,
+                "updated": 1415323797957,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000eqxw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000eqxw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000eqxw",
+                "ids": ",usp000eqxw,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 9,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": 73.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.988,
+                    51.094,
+                    10
+                ]
+            },
+            "id": "usp000eqxw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Wales, United Kingdom",
+                "time": 1159299275400,
+                "updated": 1415323816958,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000etvr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000etvr&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000etvr",
+                "ids": ",usp000etvr,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 32,
+                "dmin": null,
+                "rms": null,
+                "gap": 72.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.032,
+                    52.031,
+                    10.8
+                ]
+            },
+            "id": "usp000etvr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.4,
+                "place": "Scotland, United Kingdom",
+                "time": 1160713263800,
+                "updated": 1415323833593,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ev3e",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ev3e&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 30,
+                "net": "us",
+                "code": "p000ev3e",
+                "ids": ",usp000ev3e,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 5,
+                "dmin": null,
+                "rms": null,
+                "gap": 205.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.251,
+                    56.705,
+                    6.8
+                ]
+            },
+            "id": "usp000ev3e"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "England, United Kingdom",
+                "time": 1162766140800,
+                "updated": 1415323845742,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ewq4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ewq4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000ewq4",
+                "ids": ",usp000ewq4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 32,
+                "dmin": null,
+                "rms": null,
+                "gap": 93.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.569,
+                    52.352,
+                    10
+                ]
+            },
+            "id": "usp000ewq4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "England, United Kingdom",
+                "time": 1166494855000,
+                "updated": 1415323869868,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f0hj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f0hj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p000f0hj",
+                "ids": ",usp000f0hj,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": null,
+                "gap": 200.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.512,
+                    50.346,
+                    8
+                ]
+            },
+            "id": "usp000f0hj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "Scotland, United Kingdom",
+                "time": 1167129604400,
+                "updated": 1415323871643,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f10w",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f10w&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p000f10w",
+                "ids": ",usp000f10w,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 87,
+                "dmin": null,
+                "rms": null,
+                "gap": 50.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.634,
+                    55.085,
+                    7.7
+                ]
+            },
+            "id": "usp000f10w"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "England, United Kingdom",
+                "time": 1167470143000,
+                "updated": 1415323873175,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f1ag",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f1ag&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p000f1ag",
+                "ids": ",usp000f1ag,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 34,
+                "dmin": null,
+                "rms": null,
+                "gap": 195.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.998,
+                    53.666,
+                    11
+                ]
+            },
+            "id": "usp000f1ag"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "Scotland, United Kingdom",
+                "time": 1168994824200,
+                "updated": 1415323883812,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f2tz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f2tz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p000f2tz",
+                "ids": ",usp000f2tz,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 8,
+                "dmin": null,
+                "rms": null,
+                "gap": 176,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.624,
+                    56.942,
+                    6.2
+                ]
+            },
+            "id": "usp000f2tz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "England, United Kingdom",
+                "time": 1173891253900,
+                "updated": 1415323912511,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f6qb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f6qb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p000f6qb",
+                "ids": ",usp000f6qb,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 6,
+                "dmin": null,
+                "rms": null,
+                "gap": 204.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.254,
+                    53.458,
+                    1.3
+                ]
+            },
+            "id": "usp000f6qb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.4,
+                "place": "England, United Kingdom",
+                "time": 1174395823800,
+                "updated": 1415323914191,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f723",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f723&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 30,
+                "net": "us",
+                "code": "p000f723",
+                "ids": ",usp000f723,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 206.9,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.248,
+                    53.461,
+                    1.6
+                ]
+            },
+            "id": "usp000f723"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "England, United Kingdom",
+                "time": 1174469193900,
+                "updated": 1415323914353,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f73n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f73n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p000f73n",
+                "ids": ",usp000f73n,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 8,
+                "dmin": null,
+                "rms": null,
+                "gap": 209,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.225,
+                    53.453,
+                    1.7
+                ]
+            },
+            "id": "usp000f73n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.2,
+                "place": "England, United Kingdom",
+                "time": 1174529142800,
+                "updated": 1415323914551,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f74z",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f74z&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 22,
+                "net": "us",
+                "code": "p000f74z",
+                "ids": ",usp000f74z,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 6,
+                "dmin": null,
+                "rms": null,
+                "gap": 207.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.239,
+                    53.461,
+                    2.6
+                ]
+            },
+            "id": "usp000f74z"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "England, United Kingdom",
+                "time": 1174613879000,
+                "updated": 1415323914806,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f76w",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f76w&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p000f76w",
+                "ids": ",usp000f76w,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 9,
+                "dmin": null,
+                "rms": null,
+                "gap": 205.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.23,
+                    53.46,
+                    2.6
+                ]
+            },
+            "id": "usp000f76w"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "England, United Kingdom",
+                "time": 1175009857900,
+                "updated": 1415323916918,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f7mz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f7mz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p000f7mz",
+                "ids": ",usp000f7mz,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 211.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.212,
+                    53.476,
+                    1.9
+                ]
+            },
+            "id": "usp000f7mz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.4,
+                "place": "England, United Kingdom",
+                "time": 1175209155000,
+                "updated": 1415323917755,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000f7tw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000f7tw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 30,
+                "net": "us",
+                "code": "p000f7tw",
+                "ids": ",usp000f7tw,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 7,
+                "dmin": null,
+                "rms": null,
+                "gap": 209.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.223,
+                    53.453,
+                    2.6
+                ]
+            },
+            "id": "usp000f7tw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.6,
+                "place": "England, United Kingdom",
+                "time": 1177744691360,
+                "updated": 1600464750339,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fase",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fase&format=geojson",
+                "felt": 275,
+                "cdi": 5.6,
+                "mmi": 5.172,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 480,
+                "net": "us",
+                "code": "p000fase",
+                "ids": ",us2007bsal,usp000fase,atlas20070428071811,",
+                "sources": ",us,us,atlas,",
+                "types": ",associate,dyfi,impact-text,origin,phase-data,shakemap,trump-shakemap,",
+                "nst": 295,
+                "dmin": null,
+                "rms": 1.12,
+                "gap": 31.8,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.009,
+                    51.085,
+                    10
+                ]
+            },
+            "id": "usp000fase"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 1184692664600,
+                "updated": 1415323979004,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fgf6",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fgf6&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000fgf6",
+                "ids": ",usp000fgf6,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 10,
+                "dmin": null,
+                "rms": null,
+                "gap": 116.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.957,
+                    52.801,
+                    2.6
+                ]
+            },
+            "id": "usp000fgf6"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 1186743010900,
+                "updated": 1415323993960,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fjax",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fjax&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000fjax",
+                "ids": ",usp000fjax,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 184.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.185,
+                    53.488,
+                    4.6
+                ]
+            },
+            "id": "usp000fjax"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 1188449195500,
+                "updated": 1415324004470,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fkzp",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fkzp&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p000fkzp",
+                "ids": ",usp000fkzp,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 12,
+                "dmin": null,
+                "rms": null,
+                "gap": 72.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.178,
+                    53.482,
+                    4.5
+                ]
+            },
+            "id": "usp000fkzp"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 1194092606800,
+                "updated": 1415324046592,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000frwm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000frwm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000frwm",
+                "ids": ",usp000frwm,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 10,
+                "dmin": null,
+                "rms": null,
+                "gap": 159.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.415,
+                    51.399,
+                    0
+                ]
+            },
+            "id": "usp000frwm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 1196442536800,
+                "updated": 1415324056325,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ftkz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ftkz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000ftkz",
+                "ids": ",usp000ftkz,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 14,
+                "dmin": null,
+                "rms": null,
+                "gap": 65.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.206,
+                    55.804,
+                    6.3
+                ]
+            },
+            "id": "usp000ftkz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "Wales, United Kingdom",
+                "time": 1196460343500,
+                "updated": 1415324056361,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000ftm9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000ftm9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000ftm9",
+                "ids": ",usp000ftm9,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 51,
+                "dmin": null,
+                "rms": null,
+                "gap": 77.6,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.277,
+                    52.866,
+                    12
+                ]
+            },
+            "id": "usp000ftm9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 1197215997200,
+                "updated": 1415324062791,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fu4s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fu4s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000fu4s",
+                "ids": ",usp000fu4s,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 13,
+                "dmin": null,
+                "rms": null,
+                "gap": 88.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.221,
+                    55.788,
+                    4.7
+                ]
+            },
+            "id": "usp000fu4s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.1,
+                "place": "North Sea",
+                "time": 1199918344600,
+                "updated": 1415324079836,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000fwc5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000fwc5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 148,
+                "net": "us",
+                "code": "p000fwc5",
+                "ids": ",usp000fwc5,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 29,
+                "dmin": null,
+                "rms": null,
+                "gap": 171.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.1 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.032,
+                    58.204,
+                    20.2
+                ]
+            },
+            "id": "usp000fwc5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.8,
+                "place": "England, United Kingdom",
+                "time": 1204073807800,
+                "updated": 1600466852312,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000g02w",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000g02w&format=geojson",
+                "felt": 19102,
+                "cdi": 6.2,
+                "mmi": 5.746,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 974,
+                "net": "us",
+                "code": "p000g02w",
+                "ids": ",us2008nyae,usp000g02w,atlas20080227005647,",
+                "sources": ",us,us,atlas,",
+                "types": ",associate,dyfi,impact-text,origin,phase-data,shakemap,trump-shakemap,",
+                "nst": 361,
+                "dmin": null,
+                "rms": null,
+                "gap": 19.2,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.332,
+                    53.403,
+                    18.4
+                ]
+            },
+            "id": "usp000g02w"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "North Atlantic Ocean",
+                "time": 1206261189600,
+                "updated": 1415324118230,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000g244",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000g244&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p000g244",
+                "ids": ",usp000g244,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 20,
+                "dmin": null,
+                "rms": null,
+                "gap": 253.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - North Atlantic Ocean"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.04,
+                    50.382,
+                    6
+                ]
+            },
+            "id": "usp000g244"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.1,
+                "place": "England, United Kingdom",
+                "time": 1207403846200,
+                "updated": 1415324131496,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000g35b",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000g35b&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 148,
+                "net": "us",
+                "code": "p000g35b",
+                "ids": ",usp000g35b,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 24,
+                "dmin": null,
+                "rms": null,
+                "gap": 291.3,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.1 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.351,
+                    53.357,
+                    19.2
+                ]
+            },
+            "id": "usp000g35b"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 1212005348300,
+                "updated": 1415324167376,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000g7zy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000g7zy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p000g7zy",
+                "ids": ",usp000g7zy,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": null,
+                "gap": 89.4,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.952,
+                    54.691,
+                    6.3
+                ]
+            },
+            "id": "usp000g7zy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "England, United Kingdom",
+                "time": 1218579758100,
+                "updated": 1415324213432,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000geh4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000geh4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p000geh4",
+                "ids": ",usp000geh4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 8,
+                "dmin": null,
+                "rms": null,
+                "gap": 127,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.574,
+                    53.38,
+                    9.1
+                ]
+            },
+            "id": "usp000geh4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Scotland, United Kingdom",
+                "time": 1223612919300,
+                "updated": 1415324246726,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000gjuf",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000gjuf&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000gjuf",
+                "ids": ",usp000gjuf,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 42,
+                "dmin": null,
+                "rms": null,
+                "gap": 116.1,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.557,
+                    56.829,
+                    12.5
+                ]
+            },
+            "id": "usp000gjuf"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.9,
+                "place": "England, United Kingdom",
+                "time": 1225044386000,
+                "updated": 1415324252689,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000gm35",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000gm35&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 234,
+                "net": "us",
+                "code": "p000gm35",
+                "ids": ",usp000gm35,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 96,
+                "dmin": null,
+                "rms": null,
+                "gap": 53.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.512,
+                    52.212,
+                    9.3
+                ]
+            },
+            "id": "usp000gm35"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "France",
+                "time": 1227704156100,
+                "updated": 1415324268267,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000gpg5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000gpg5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000gpg5",
+                "ids": ",usp000gpg5,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 6,
+                "dmin": null,
+                "rms": null,
+                "gap": 217.6,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.18,
+                    50.44,
+                    5
+                ]
+            },
+            "id": "usp000gpg5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "England, United Kingdom",
+                "time": 1236090955900,
+                "updated": 1427158722538,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000guke",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000guke&format=geojson",
+                "felt": 17,
+                "cdi": 4.1,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 195,
+                "net": "us",
+                "code": "p000guke",
+                "ids": ",usp000guke,us2009dtbd,",
+                "sources": ",us,us,",
+                "types": ",associate,dyfi,impact-text,origin,phase-data,",
+                "nst": 17,
+                "dmin": null,
+                "rms": null,
+                "gap": 93.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.178,
+                    51.116,
+                    3.5
+                ]
+            },
+            "id": "usp000guke"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 1239449947200,
+                "updated": 1415324325948,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000gw15",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000gw15&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000gw15",
+                "ids": ",usp000gw15,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 23,
+                "dmin": null,
+                "rms": null,
+                "gap": 159.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.252,
+                    53.687,
+                    15.3
+                ]
+            },
+            "id": "usp000gw15"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 1240914129510,
+                "updated": 1415324330565,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000gwn8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000gwn8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p000gwn8",
+                "ids": ",usp000gwn8,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 70,
+                "dmin": null,
+                "rms": null,
+                "gap": 91.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.017,
+                    54.167,
+                    8.8
+                ]
+            },
+            "id": "usp000gwn8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "England, United Kingdom",
+                "time": 1292972352700,
+                "updated": 1415324591102,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000hrck",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000hrck&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000hrck",
+                "ids": ",usp000hrck,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 31,
+                "dmin": null,
+                "rms": null,
+                "gap": 62.5,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.146,
+                    54.39,
+                    12.6
+                ]
+            },
+            "id": "usp000hrck"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "England, United Kingdom",
+                "time": 1294088589400,
+                "updated": 1427161168910,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000hsj4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000hsj4&format=geojson",
+                "felt": 494,
+                "cdi": 3.8,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 387,
+                "net": "us",
+                "code": "p000hsj4",
+                "ids": ",us2011frb5,usp000hsj4,",
+                "sources": ",us,us,",
+                "types": ",associate,dyfi,impact-text,origin,phase-data,",
+                "nst": 23,
+                "dmin": null,
+                "rms": null,
+                "gap": 88,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.652,
+                    54.169,
+                    6
+                ]
+            },
+            "id": "usp000hsj4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Scotland, United Kingdom",
+                "time": 1295762569300,
+                "updated": 1415324608776,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000hthp",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000hthp&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p000hthp",
+                "ids": ",usp000hthp,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 13,
+                "dmin": null,
+                "rms": null,
+                "gap": 150.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.784,
+                    56.822,
+                    16.2
+                ]
+            },
+            "id": "usp000hthp"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "England, United Kingdom",
+                "time": 1308836618100,
+                "updated": 1415324709370,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000j3m3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000j3m3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p000j3m3",
+                "ids": ",usp000j3m3,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 10,
+                "dmin": null,
+                "rms": null,
+                "gap": 177.9,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.734,
+                    50.571,
+                    2.8
+                ]
+            },
+            "id": "usp000j3m3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.9,
+                "place": "England, United Kingdom",
+                "time": 1310626750900,
+                "updated": 1415324721736,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000j4v4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000j4v4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 234,
+                "net": "us",
+                "code": "p000j4v4",
+                "ids": ",usp000j4v4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 85,
+                "dmin": null,
+                "rms": null,
+                "gap": 47.7,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.743,
+                    50.122,
+                    10
+                ]
+            },
+            "id": "usp000j4v4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 1358486444400,
+                "updated": 1427162405562,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000jyhq",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000jyhq&format=geojson",
+                "felt": 28,
+                "cdi": 4.1,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 141,
+                "net": "us",
+                "code": "p000jyhq",
+                "ids": ",usb000equa,usp000jyhq,",
+                "sources": ",us,us,",
+                "types": ",associate,dyfi,impact-text,origin,phase-data,",
+                "nst": 19,
+                "dmin": null,
+                "rms": null,
+                "gap": 77.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.25,
+                    52.801,
+                    13
+                ]
+            },
+            "id": "usp000jyhq"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "3km SE of Caernarfon, United Kingdom",
+                "time": 1360276864000,
+                "updated": 1422627551111,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usc000f3w6",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usc000f3w6&format=geojson",
+                "felt": 5,
+                "cdi": 2.7,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 83,
+                "net": "us",
+                "code": "c000f3w6",
+                "ids": ",usc000f3w6,",
+                "sources": ",us,",
+                "types": ",dyfi,eq-location-map,general-link,geoserve,historical-moment-tensor-map,historical-seismicity-map,impact-text,nearby-cities,origin,p-wave-travel-times,phase-data,",
+                "nst": 4,
+                "dmin": null,
+                "rms": null,
+                "gap": 137.8,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - 3km SE of Caernarfon, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.231,
+                    53.125,
+                    9
+                ]
+            },
+            "id": "usc000f3w6"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "37km W of Fort William, United Kingdom",
+                "time": 1368904682790,
+                "updated": 1415325049942,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2013qib5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2013qib5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "2013qib5",
+                "ids": ",us2013qib5,",
+                "sources": ",us,",
+                "types": ",general-link,geoserve,impact-text,nearby-cities,origin,p-wave-travel-times,phase-data,",
+                "nst": 6,
+                "dmin": null,
+                "rms": null,
+                "gap": 100,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - 37km W of Fort William, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.715,
+                    56.776,
+                    10
+                ]
+            },
+            "id": "us2013qib5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "15km WSW of Nefyn, United Kingdom",
+                "time": 1369797388900,
+                "updated": 1422488518679,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usb000h7yc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usb000h7yc&format=geojson",
+                "felt": 49,
+                "cdi": 4.4,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 244,
+                "net": "us",
+                "code": "b000h7yc",
+                "ids": ",usb000h7yc,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,general-link,geoserve,impact-text,nearby-cities,origin,p-wave-travel-times,phase-data,",
+                "nst": 74,
+                "dmin": null,
+                "rms": null,
+                "gap": 135.2,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - 15km WSW of Nefyn, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.719,
+                    52.883,
+                    10
+                ]
+            },
+            "id": "usb000h7yc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Wales, United Kingdom",
+                "time": 1372285681500,
+                "updated": 1415325067631,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000k1gg",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000k1gg&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p000k1gg",
+                "ids": ",usp000k1gg,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": 5,
+                "dmin": null,
+                "rms": null,
+                "gap": 100,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.72,
+                    52.879,
+                    8
+                ]
+            },
+            "id": "usp000k1gg"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "24km WNW of Blackpool, United Kingdom",
+                "time": 1377424715800,
+                "updated": 1422617929905,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usb000jbmh",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usb000jbmh&format=geojson",
+                "felt": 6,
+                "cdi": 3.9,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 160,
+                "net": "us",
+                "code": "b000jbmh",
+                "ids": ",usb000jbmh,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,general-link,geoserve,impact-text,nearby-cities,origin,p-wave-travel-times,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.61,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - 24km WNW of Blackpool, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.403,
+                    53.887,
+                    8
+                ]
+            },
+            "id": "usb000jbmh"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.1,
+                "place": "17km NNW of Ilfracombe, United Kingdom",
+                "time": 1392902490000,
+                "updated": 1399420984000,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usc000muba",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usc000muba&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 259,
+                "net": "us",
+                "code": "c000muba",
+                "ids": ",usc000muba,",
+                "sources": ",us,",
+                "types": ",cap,general-link,geoserve,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.87,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.1 - 17km NNW of Ilfracombe, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.164,
+                    51.363,
+                    3
+                ]
+            },
+            "id": "usc000muba"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "1km NW of Ashwell, United Kingdom",
+                "time": 1397803851500,
+                "updated": 1404437614000,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usb000ppvz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usb000ppvz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "b000ppvz",
+                "ids": ",usb000ppvz,",
+                "sources": ",us,",
+                "types": ",cap,general-link,geoserve,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.55,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - 1km NW of Ashwell, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.732,
+                    52.722,
+                    2
+                ]
+            },
+            "id": "usb000ppvz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "2km NNE of Hucknall Torkard, United Kingdom",
+                "time": 1414523814600,
+                "updated": 1421457943040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usb000srj4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usb000srj4&format=geojson",
+                "felt": 1,
+                "cdi": 2.5,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "b000srj4",
+                "ids": ",usb000srj4,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.41,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - 2km NNE of Hucknall Torkard, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.191,
+                    53.057,
+                    7
+                ]
+            },
+            "id": "usb000srj4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "1km ENE of Winchester, United Kingdom",
+                "time": 1422383417600,
+                "updated": 1429894545040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usc000tjwr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usc000tjwr&format=geojson",
+                "felt": 3,
+                "cdi": 3.1,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 130,
+                "net": "us",
+                "code": "c000tjwr",
+                "ids": ",usc000tjwr,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.01,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - 1km ENE of Winchester, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.299,
+                    51.072,
+                    3
+                ]
+            },
+            "id": "usc000tjwr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "1km N of Ashwell, United Kingdom",
+                "time": 1422483953700,
+                "updated": 1429894545040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usc000tjwv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usc000tjwv&format=geojson",
+                "felt": 147,
+                "cdi": 4.6,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 290,
+                "net": "us",
+                "code": "c000tjwv",
+                "ids": ",usc000tjwv,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.83,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - 1km N of Ashwell, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.717,
+                    52.727,
+                    3
+                ]
+            },
+            "id": "usc000tjwv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "3km SSE of Ramsgate, United Kingdom",
+                "time": 1432259537900,
+                "updated": 1456503738410,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us10002bap",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us10002bap&format=geojson",
+                "felt": 154,
+                "cdi": 4.3,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 277,
+                "net": "us",
+                "code": "10002bap",
+                "ids": ",us10002bap,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,moment-tensor,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.84,
+                "gap": null,
+                "magType": "mwr",
+                "type": "earthquake",
+                "title": "M 3.7 - 3km SSE of Ramsgate, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.438,
+                    51.304,
+                    12
+                ]
+            },
+            "id": "us10002bap"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "5km WNW of Llanwnda, United Kingdom",
+                "time": 1432654863800,
+                "updated": 1438133745040,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us10002cc4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us10002cc4&format=geojson",
+                "felt": 5,
+                "cdi": 3.8,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 140,
+                "net": "us",
+                "code": "10002cc4",
+                "ids": ",us10002cc4,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.75,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - 5km WNW of Llanwnda, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.355,
+                    53.116,
+                    9
+                ]
+            },
+            "id": "us10002cc4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "1km E of Ashwell, United Kingdom",
+                "time": 1442958011200,
+                "updated": 1450739793040,
+                "tz": 60,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us20003n3q",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us20003n3q&format=geojson",
+                "felt": 10,
+                "cdi": 3.4,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 124,
+                "net": "us",
+                "code": "20003n3q",
+                "ids": ",us20003n3q,",
+                "sources": ",us,",
+                "types": ",cap,dyfi,geoserve,impact-text,nearby-cities,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - 1km E of Ashwell, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.693,
+                    52.714,
+                    2
+                ]
+            },
+            "id": "us20003n3q"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "37km W of Fort William, United Kingdom",
+                "time": 1501857816590,
+                "updated": 1508291658040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000a62y",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000a62y&format=geojson",
+                "felt": 9,
+                "cdi": 4.3,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 226,
+                "net": "us",
+                "code": "2000a62y",
+                "ids": ",us2000a62y,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": 2.08,
+                "rms": 0.59,
+                "gap": 137,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - 37km W of Fort William, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.7295,
+                    56.8378,
+                    7.07
+                ]
+            },
+            "id": "us2000a62y"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "2km NNW of Tarbert, United Kingdom",
+                "time": 1509569962000,
+                "updated": 1516757104040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000bf5x",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000bf5x&format=geojson",
+                "felt": 30,
+                "cdi": 3.2,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 114,
+                "net": "us",
+                "code": "2000bf5x",
+                "ids": ",us2000bf5x,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.55,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - 2km NNW of Tarbert, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.429,
+                    55.883,
+                    7
+                ]
+            },
+            "id": "us2000bf5x"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "5km NE of Clydach, United Kingdom",
+                "time": 1518877865070,
+                "updated": 1594400643878,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000d3uw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000d3uw&format=geojson",
+                "felt": 3708,
+                "cdi": 4.8,
+                "mmi": 4.638,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 764,
+                "net": "us",
+                "code": "2000d3uw",
+                "ids": ",us2000d3uw,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,impact-text,origin,phase-data,shakemap,",
+                "nst": null,
+                "dmin": 2.167,
+                "rms": 1.14,
+                "gap": 92,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.3 - 5km NE of Clydach, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.8559,
+                    51.7231,
+                    11.55
+                ]
+            },
+            "id": "us2000d3uw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "6km NW of Langley Green, United Kingdom",
+                "time": 1522581061000,
+                "updated": 1529703139040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us1000dc9r",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us1000dc9r&format=geojson",
+                "felt": 22,
+                "cdi": 3.3,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 119,
+                "net": "us",
+                "code": "1000dc9r",
+                "ids": ",us1000dc9r,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.07,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - 6km NW of Langley Green, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.257,
+                    51.174,
+                    5
+                ]
+            },
+            "id": "us1000dc9r"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.1,
+                "place": "7km NNE of Withernsea, United Kingdom",
+                "time": 1528582465670,
+                "updated": 1535560582040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us1000emw5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us1000emw5&format=geojson",
+                "felt": 33,
+                "cdi": 3.9,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 271,
+                "net": "us",
+                "code": "1000emw5",
+                "ids": ",us1000emw5,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": 2.438,
+                "rms": 1.01,
+                "gap": 76,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.1 - 7km NNE of Withernsea, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.0603,
+                    53.7927,
+                    10
+                ]
+            },
+            "id": "us1000emw5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "5km NW of Langley Green, United Kingdom",
+                "time": 1530102503700,
+                "updated": 1537547147040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000fpl7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000fpl7&format=geojson",
+                "felt": 17,
+                "cdi": 3.8,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 110,
+                "net": "us",
+                "code": "2000fpl7",
+                "ids": ",us2000fpl7,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - 5km NW of Langley Green, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.258,
+                    51.154,
+                    5
+                ]
+            },
+            "id": "us2000fpl7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "5km WNW of Langley Green, United Kingdom",
+                "time": 1530251652600,
+                "updated": 1537547147040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000ft87",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000ft87&format=geojson",
+                "felt": 3,
+                "cdi": 2,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "2000ft87",
+                "ids": ",us2000ft87,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - 5km WNW of Langley Green, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.265,
+                    51.152,
+                    5
+                ]
+            },
+            "id": "us2000ft87"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "2km E of Cranleigh, United Kingdom",
+                "time": 1530788004180,
+                "updated": 1551245211157,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000fxc7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000fxc7&format=geojson",
+                "felt": 171,
+                "cdi": 4.2,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 192,
+                "net": "us",
+                "code": "2000fxc7",
+                "ids": ",us2000fxc7,",
+                "sources": ",us,",
+                "types": ",dyfi,geoserve,origin,phase-data,",
+                "nst": null,
+                "dmin": 3.582,
+                "rms": 0.41,
+                "gap": 190,
+                "magType": "mb_lg",
+                "type": "earthquake",
+                "title": "M 2.8 - 2km E of Cranleigh, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.4435,
+                    51.1437,
+                    10
+                ]
+            },
+            "id": "us2000fxc7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "1km ENE of Gourock, United Kingdom",
+                "time": 1535668487620,
+                "updated": 1541615829040,
+                "tz": 0,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/us2000h6y0",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us2000h6y0&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "2000h6y0",
+                "ids": ",us2000h6y0,",
+                "sources": ",us,",
+                "types": ",geoserve,impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": 1.112,
+                "rms": 0.26,
+                "gap": 211,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - 1km ENE of Gourock, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.7957,
+                    55.9663,
+                    10
+                ]
+            },
+            "id": "us2000h6y0"
+        }
+    ],
+    "bbox": [
+        -6.04,
+        50.048,
+        0,
+        1.582,
+        58.204,
+        28.7
+    ]
+}

--- a/week04/quakes.txt
+++ b/week04/quakes.txt
@@ -1,14 +1,8454 @@
 {
     "type": "FeatureCollection",
     "metadata": {
-        "generated": 1603660656000,
-        "url": "https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?starttime=2000-01-01&maxlatitude=58.723&minlatitude=50.008&maxlongitude=1.67&minlongitude=-9.756&minmagnitude=1&endtime=2018-10-11&orderby=time-asc",
+        "generated": 1603661326000,
+        "url": "https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?starttime=1900-01-01&maxlatitude=58.723&minlatitude=50.008&maxlongitude=1.67&minlongitude=-9.756&minmagnitude=1&endtime=2018-10-11&orderby=time-asc",
         "title": "USGS Earthquakes",
         "status": 200,
         "api": "1.10.3",
-        "count": 120
+        "count": 331
     },
     "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "Wales-England region, United Kingdom",
+                "time": 131054624100,
+                "updated": 1415316083003,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00005dn",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00005dn&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 284,
+                "net": "us",
+                "code": "p00005dn",
+                "ids": ",usp00005dn,",
+                "sources": ",us,",
+                "types": ",origin,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.3 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.039,
+                    51.578,
+                    33
+                ]
+            },
+            "id": "usp00005dn"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "Scotland, United Kingdom",
+                "time": 145370978000,
+                "updated": 1415316085719,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00007hv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00007hv&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 284,
+                "net": "us",
+                "code": "p00007hv",
+                "ids": ",usp00007hv,",
+                "sources": ",us,",
+                "types": ",origin,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.21,
+                    57.147,
+                    10
+                ]
+            },
+            "id": "usp00007hv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.5,
+                "place": "England, United Kingdom",
+                "time": 315028624300,
+                "updated": 1598474822069,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00014q1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00014q1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": 5.61,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 312,
+                "net": "us",
+                "code": "p00014q1",
+                "ids": ",usp00014q1,atlas19791226035704,",
+                "sources": ",us,atlas,",
+                "types": ",impact-text,origin,shakemap,trump-shakemap,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.683,
+                    54.903,
+                    10
+                ]
+            },
+            "id": "usp00014q1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "Wales, United Kingdom",
+                "time": 397740301600,
+                "updated": 1415320304900,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0001nxm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0001nxm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0001nxm",
+                "ids": ",usp0001nxm,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.557,
+                    52.966,
+                    10
+                ]
+            },
+            "id": "usp0001nxm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "Irish Sea",
+                "time": 401732905790,
+                "updated": 1415320314623,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0001pt2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0001pt2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p0001pt2",
+                "ids": ",usp0001pt2,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - Irish Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.661,
+                    53.322,
+                    10
+                ]
+            },
+            "id": "usp0001pt2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "Scotland, United Kingdom",
+                "time": 445774545560,
+                "updated": 1415320470693,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002210",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002210&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p0002210",
+                "ids": ",usp0002210,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.632,
+                    55.05,
+                    9.3
+                ]
+            },
+            "id": "usp0002210"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 448805393020,
+                "updated": 1415320479088,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00022vu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00022vu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p00022vu",
+                "ids": ",usp00022vu,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.073,
+                    53.08,
+                    10
+                ]
+            },
+            "id": "usp00022vu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "England, United Kingdom",
+                "time": 449850430070,
+                "updated": 1415320483792,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002381",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002381&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 222,
+                "net": "us",
+                "code": "p0002381",
+                "ids": ",usp0002381,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.643,
+                    50.58,
+                    10
+                ]
+            },
+            "id": "usp0002381"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "Wales, United Kingdom",
+                "time": 450911133920,
+                "updated": 1415320486061,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00023kd",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00023kd&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p00023kd",
+                "ids": ",usp00023kd,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.356,
+                    52.204,
+                    19.5
+                ]
+            },
+            "id": "usp00023kd"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "Wales, United Kingdom",
+                "time": 452452521990,
+                "updated": 1415320492047,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000243u",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000243u&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p000243u",
+                "ids": ",usp000243u,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.83,
+                    53.311,
+                    10
+                ]
+            },
+            "id": "usp000243u"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "Irish Sea",
+                "time": 454583127420,
+                "updated": 1415320496493,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00024p7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00024p7&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p00024p7",
+                "ids": ",usp00024p7,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - Irish Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.187,
+                    52.755,
+                    10
+                ]
+            },
+            "id": "usp00024p7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 454733635320,
+                "updated": 1415320496724,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00024qn",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00024qn&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p00024qn",
+                "ids": ",usp00024qn,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.035,
+                    52.742,
+                    10
+                ]
+            },
+            "id": "usp00024qn"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 5,
+                "place": "Wales, United Kingdom",
+                "time": 459068170480,
+                "updated": 1598484848961,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025ue",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025ue&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": 6.325,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 385,
+                "net": "us",
+                "code": "p00025ue",
+                "ids": ",usp00025ue,atlas19840719065610,",
+                "sources": ",us,atlas,",
+                "types": ",impact-text,origin,phase-data,shakemap,trump-shakemap,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 5.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.198,
+                    52.878,
+                    12.9
+                ]
+            },
+            "id": "usp00025ue"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Wales, United Kingdom",
+                "time": 459068760200,
+                "updated": 1415320512055,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025uf",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025uf&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p00025uf",
+                "ids": ",usp00025uf,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.362,
+                    52.906,
+                    10
+                ]
+            },
+            "id": "usp00025uf"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Wales, United Kingdom",
+                "time": 459068885210,
+                "updated": 1415320512057,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025ug",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025ug&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p00025ug",
+                "ids": ",usp00025ug,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.398,
+                    53.005,
+                    9.9
+                ]
+            },
+            "id": "usp00025ug"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Wales, United Kingdom",
+                "time": 459076618410,
+                "updated": 1415320512064,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025um",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025um&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p00025um",
+                "ids": ",usp00025um,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.168,
+                    52.883,
+                    10
+                ]
+            },
+            "id": "usp00025um"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Wales, United Kingdom",
+                "time": 459078124540,
+                "updated": 1415320512066,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025un",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025un&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p00025un",
+                "ids": ",usp00025un,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.245,
+                    52.87,
+                    10
+                ]
+            },
+            "id": "usp00025un"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Wales, United Kingdom",
+                "time": 459078994310,
+                "updated": 1415320512070,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025up",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025up&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p00025up",
+                "ids": ",usp00025up,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.344,
+                    53.001,
+                    10
+                ]
+            },
+            "id": "usp00025up"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Wales, United Kingdom",
+                "time": 459090157680,
+                "updated": 1415320512074,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025ur",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025ur&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p00025ur",
+                "ids": ",usp00025ur,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.324,
+                    52.986,
+                    10
+                ]
+            },
+            "id": "usp00025ur"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Wales, United Kingdom",
+                "time": 459118395770,
+                "updated": 1415320512110,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025uy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025uy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p00025uy",
+                "ids": ",usp00025uy,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.305,
+                    52.961,
+                    10
+                ]
+            },
+            "id": "usp00025uy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Wales, United Kingdom",
+                "time": 459151221240,
+                "updated": 1415320512175,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025v5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025v5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p00025v5",
+                "ids": ",usp00025v5,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.379,
+                    53.022,
+                    10
+                ]
+            },
+            "id": "usp00025v5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Wales, United Kingdom",
+                "time": 459176162660,
+                "updated": 1415320512189,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025vb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025vb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p00025vb",
+                "ids": ",usp00025vb,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.399,
+                    53.014,
+                    10
+                ]
+            },
+            "id": "usp00025vb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "United Kingdom",
+                "time": 459179207800,
+                "updated": 1415320512190,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025vc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025vc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p00025vc",
+                "ids": ",usp00025vc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.852,
+                    53.035,
+                    10
+                ]
+            },
+            "id": "usp00025vc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Wales, United Kingdom",
+                "time": 459185169360,
+                "updated": 1415320512216,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025ve",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025ve&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p00025ve",
+                "ids": ",usp00025ve,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.159,
+                    52.915,
+                    10
+                ]
+            },
+            "id": "usp00025ve"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Wales, United Kingdom",
+                "time": 459229541480,
+                "updated": 1415320512335,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025w0",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025w0&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p00025w0",
+                "ids": ",usp00025w0,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.289,
+                    52.958,
+                    10
+                ]
+            },
+            "id": "usp00025w0"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Wales, United Kingdom",
+                "time": 459266105590,
+                "updated": 1415320512363,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025w8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025w8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p00025w8",
+                "ids": ",usp00025w8,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.324,
+                    52.983,
+                    10
+                ]
+            },
+            "id": "usp00025w8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.8,
+                "place": "Wales, United Kingdom",
+                "time": 459368852220,
+                "updated": 1415320512497,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025xa",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025xa&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 50,
+                "net": "us",
+                "code": "p00025xa",
+                "ids": ",usp00025xa,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.8 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.327,
+                    53.025,
+                    10
+                ]
+            },
+            "id": "usp00025xa"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "Wales, United Kingdom",
+                "time": 459403736470,
+                "updated": 1415320512529,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025xj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025xj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p00025xj",
+                "ids": ",usp00025xj,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.364,
+                    53.008,
+                    10
+                ]
+            },
+            "id": "usp00025xj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Wales, United Kingdom",
+                "time": 459419365680,
+                "updated": 1415320512605,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025xt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025xt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p00025xt",
+                "ids": ",usp00025xt,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.388,
+                    53.016,
+                    10
+                ]
+            },
+            "id": "usp00025xt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "United Kingdom",
+                "time": 459531766670,
+                "updated": 1415320512758,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025yu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025yu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p00025yu",
+                "ids": ",usp00025yu,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.834,
+                    53.009,
+                    10
+                ]
+            },
+            "id": "usp00025yu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Wales, United Kingdom",
+                "time": 459583711310,
+                "updated": 1415320512789,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00025z8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00025z8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p00025z8",
+                "ids": ",usp00025z8,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.271,
+                    52.947,
+                    10
+                ]
+            },
+            "id": "usp00025z8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "Wales, United Kingdom",
+                "time": 459715266060,
+                "updated": 1415320512976,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000260d",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000260d&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p000260d",
+                "ids": ",usp000260d,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.395,
+                    53.023,
+                    10
+                ]
+            },
+            "id": "usp000260d"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.1,
+                "place": "Wales, United Kingdom",
+                "time": 459780967030,
+                "updated": 1415320513016,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000260r",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000260r&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 259,
+                "net": "us",
+                "code": "p000260r",
+                "ids": ",usp000260r,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.1 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.18,
+                    52.898,
+                    10
+                ]
+            },
+            "id": "usp000260r"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "Wales, United Kingdom",
+                "time": 459811775790,
+                "updated": 1415320513079,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002610",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002610&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p0002610",
+                "ids": ",usp0002610,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.342,
+                    53.007,
+                    10
+                ]
+            },
+            "id": "usp0002610"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Wales, United Kingdom",
+                "time": 459908741380,
+                "updated": 1415320513199,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000261x",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000261x&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p000261x",
+                "ids": ",usp000261x,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.332,
+                    52.987,
+                    10
+                ]
+            },
+            "id": "usp000261x"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Wales, United Kingdom",
+                "time": 459910080570,
+                "updated": 1415320513200,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000261y",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000261y&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000261y",
+                "ids": ",usp000261y,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.41,
+                    53.042,
+                    10
+                ]
+            },
+            "id": "usp000261y"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "Wales, United Kingdom",
+                "time": 459980273420,
+                "updated": 1415320513311,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000262v",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000262v&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 284,
+                "net": "us",
+                "code": "p000262v",
+                "ids": ",usp000262v,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.222,
+                    52.876,
+                    10
+                ]
+            },
+            "id": "usp000262v"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "Wales, United Kingdom",
+                "time": 459981919840,
+                "updated": 1415320513320,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000262y",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000262y&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000262y",
+                "ids": ",usp000262y,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.379,
+                    53.002,
+                    10
+                ]
+            },
+            "id": "usp000262y"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Wales, United Kingdom",
+                "time": 459998674360,
+                "updated": 1415320513350,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002639",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002639&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0002639",
+                "ids": ",usp0002639,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.389,
+                    53.021,
+                    10
+                ]
+            },
+            "id": "usp0002639"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "Wales, United Kingdom",
+                "time": 460023143870,
+                "updated": 1415320513377,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000263k",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000263k&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p000263k",
+                "ids": ",usp000263k,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.217,
+                    52.918,
+                    10
+                ]
+            },
+            "id": "usp000263k"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Wales, United Kingdom",
+                "time": 460029575160,
+                "updated": 1415320513380,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000263n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000263n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p000263n",
+                "ids": ",usp000263n,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.331,
+                    53.004,
+                    10
+                ]
+            },
+            "id": "usp000263n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "Wales, United Kingdom",
+                "time": 460048548710,
+                "updated": 1415320513404,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000263w",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000263w&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000263w",
+                "ids": ",usp000263w,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.126,
+                    52.86,
+                    10
+                ]
+            },
+            "id": "usp000263w"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "Wales, United Kingdom",
+                "time": 460150124400,
+                "updated": 1415320513502,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000264t",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000264t&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p000264t",
+                "ids": ",usp000264t,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.243,
+                    52.967,
+                    10
+                ]
+            },
+            "id": "usp000264t"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Wales, United Kingdom",
+                "time": 460177656840,
+                "updated": 1415320514965,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002653",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002653&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p0002653",
+                "ids": ",usp0002653,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.809,
+                    52.875,
+                    10
+                ]
+            },
+            "id": "usp0002653"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Wales, United Kingdom",
+                "time": 460439048910,
+                "updated": 1415320516610,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002672",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002672&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0002672",
+                "ids": ",usp0002672,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.254,
+                    52.916,
+                    10
+                ]
+            },
+            "id": "usp0002672"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "Wales, United Kingdom",
+                "time": 460451350560,
+                "updated": 1415320516625,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002675",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002675&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0002675",
+                "ids": ",usp0002675,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.299,
+                    52.969,
+                    10
+                ]
+            },
+            "id": "usp0002675"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Wales, United Kingdom",
+                "time": 460588578570,
+                "updated": 1415320516866,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002680",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002680&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p0002680",
+                "ids": ",usp0002680,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.26,
+                    52.939,
+                    10
+                ]
+            },
+            "id": "usp0002680"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.9,
+                "place": "Wales, United Kingdom",
+                "time": 460624937510,
+                "updated": 1415320516904,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002685",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002685&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 234,
+                "net": "us",
+                "code": "p0002685",
+                "ids": ",usp0002685,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.9,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.9 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.208,
+                    52.895,
+                    10
+                ]
+            },
+            "id": "usp0002685"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Wales, United Kingdom",
+                "time": 461118700100,
+                "updated": 1415320518356,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026c0",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026c0&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p00026c0",
+                "ids": ",usp00026c0,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.328,
+                    52.983,
+                    10
+                ]
+            },
+            "id": "usp00026c0"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Wales, United Kingdom",
+                "time": 461131587540,
+                "updated": 1415320518397,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026c7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026c7&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p00026c7",
+                "ids": ",usp00026c7,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.287,
+                    52.954,
+                    10
+                ]
+            },
+            "id": "usp00026c7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.3,
+                "place": "Wales, United Kingdom",
+                "time": 461677044120,
+                "updated": 1415320519346,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026gt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026gt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 284,
+                "net": "us",
+                "code": "p00026gt",
+                "ids": ",usp00026gt,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.236,
+                    52.891,
+                    10
+                ]
+            },
+            "id": "usp00026gt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "Wales, United Kingdom",
+                "time": 462047352950,
+                "updated": 1415320519869,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026mq",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026mq&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p00026mq",
+                "ids": ",usp00026mq,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.242,
+                    52.921,
+                    10
+                ]
+            },
+            "id": "usp00026mq"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Wales, United Kingdom",
+                "time": 462235121610,
+                "updated": 1415320520106,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026px",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026px&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p00026px",
+                "ids": ",usp00026px,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.18,
+                    52.883,
+                    10
+                ]
+            },
+            "id": "usp00026px"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1,
+                "place": "Wales, United Kingdom",
+                "time": 462235498550,
+                "updated": 1415320520110,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00026pz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00026pz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 15,
+                "net": "us",
+                "code": "p00026pz",
+                "ids": ",usp00026pz,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.0 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.22,
+                    52.902,
+                    10
+                ]
+            },
+            "id": "usp00026pz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 466522038600,
+                "updated": 1415320534394,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000284c",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000284c&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p000284c",
+                "ids": ",usp000284c,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.514,
+                    53.768,
+                    10
+                ]
+            },
+            "id": "usp000284c"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "England, United Kingdom",
+                "time": 469367480340,
+                "updated": 1415320542886,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002938",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002938&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0002938",
+                "ids": ",usp0002938,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.307,
+                    50.5,
+                    10
+                ]
+            },
+            "id": "usp0002938"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "Wales, United Kingdom",
+                "time": 470295924680,
+                "updated": 1415320544902,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00029g0",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00029g0&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p00029g0",
+                "ids": ",usp00029g0,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.34,
+                    52.951,
+                    10
+                ]
+            },
+            "id": "usp00029g0"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "Wales, United Kingdom",
+                "time": 470996282170,
+                "updated": 1415320549380,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00029sc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00029sc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p00029sc",
+                "ids": ",usp00029sc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.292,
+                    53.939,
+                    10
+                ]
+            },
+            "id": "usp00029sc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "France",
+                "time": 473175667910,
+                "updated": 1415320554977,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002ahc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002ahc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0002ahc",
+                "ids": ",usp0002ahc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.404,
+                    50.899,
+                    10
+                ]
+            },
+            "id": "usp0002ahc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 482439727010,
+                "updated": 1415320586882,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002dun",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002dun&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p0002dun",
+                "ids": ",usp0002dun,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.402,
+                    51.373,
+                    10
+                ]
+            },
+            "id": "usp0002dun"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Scotland, United Kingdom",
+                "time": 490667674580,
+                "updated": 1415320612814,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002gxf",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002gxf&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p0002gxf",
+                "ids": ",usp0002gxf,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.341,
+                    55.206,
+                    10
+                ]
+            },
+            "id": "usp0002gxf"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "Wales-England region, United Kingdom",
+                "time": 493442646000,
+                "updated": 1415320622142,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002hyv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002hyv&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0002hyv",
+                "ids": ",usp0002hyv,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.115,
+                    51.837,
+                    10
+                ]
+            },
+            "id": "usp0002hyv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "Scotland, United Kingdom",
+                "time": 495751811890,
+                "updated": 1415320630654,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002ju1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002ju1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0002ju1",
+                "ids": ",usp0002ju1,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.075,
+                    56.037,
+                    11
+                ]
+            },
+            "id": "usp0002ju1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "Scotland, United Kingdom",
+                "time": 502305529940,
+                "updated": 1415320654045,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002nf4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002nf4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p0002nf4",
+                "ids": ",usp0002nf4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.073,
+                    56.99,
+                    10
+                ]
+            },
+            "id": "usp0002nf4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 502393229350,
+                "updated": 1415320654635,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002ng7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002ng7&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0002ng7",
+                "ids": ",usp0002ng7,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.749,
+                    51.165,
+                    13
+                ]
+            },
+            "id": "usp0002ng7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 505182870630,
+                "updated": 1415320664557,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002pr1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002pr1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0002pr1",
+                "ids": ",usp0002pr1,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.418,
+                    57.704,
+                    5
+                ]
+            },
+            "id": "usp0002pr1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "Wales, United Kingdom",
+                "time": 505245729950,
+                "updated": 1415320664817,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002prt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002prt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p0002prt",
+                "ids": ",usp0002prt,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.412,
+                    53,
+                    10
+                ]
+            },
+            "id": "usp0002prt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Bristol Channel region, United Kingdom",
+                "time": 506988261380,
+                "updated": 1415320668635,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002qd9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002qd9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0002qd9",
+                "ids": ",usp0002qd9,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Bristol Channel region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.861,
+                    51.294,
+                    10
+                ]
+            },
+            "id": "usp0002qd9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Scotland, United Kingdom",
+                "time": 507465176190,
+                "updated": 1415320669497,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002qjw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002qjw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0002qjw",
+                "ids": ",usp0002qjw,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.386,
+                    56.982,
+                    10
+                ]
+            },
+            "id": "usp0002qjw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "northern Ireland, United Kingdom region",
+                "time": 508238095250,
+                "updated": 1415320673996,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002qu8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002qu8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0002qu8",
+                "ids": ",usp0002qu8,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "explosion",
+                "title": "M 2.5 Explosion - northern Ireland, United Kingdom region"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.296,
+                    54.871,
+                    0
+                ]
+            },
+            "id": "usp0002qu8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 519051896790,
+                "updated": 1415320712681,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002v0z",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002v0z&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0002v0z",
+                "ids": ",usp0002v0z,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.098,
+                    50.07,
+                    10
+                ]
+            },
+            "id": "usp0002v0z"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 525007630480,
+                "updated": 1415320733015,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002xct",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002xct&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0002xct",
+                "ids": ",usp0002xct,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.137,
+                    55.855,
+                    10
+                ]
+            },
+            "id": "usp0002xct"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.2,
+                "place": "Scotland, United Kingdom",
+                "time": 528341611220,
+                "updated": 1415320743738,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002ygb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002ygb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 271,
+                "net": "us",
+                "code": "p0002ygb",
+                "ids": ",usp0002ygb,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.857,
+                    56.483,
+                    10
+                ]
+            },
+            "id": "usp0002ygb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Scotland, United Kingdom",
+                "time": 529246527360,
+                "updated": 1415320748400,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0002ytd",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0002ytd&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0002ytd",
+                "ids": ",usp0002ytd,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "explosion",
+                "title": "M 2.8 Explosion - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.198,
+                    55.827,
+                    0
+                ]
+            },
+            "id": "usp0002ytd"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Wales, United Kingdom",
+                "time": 532747340850,
+                "updated": 1415320761672,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000305b",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000305b&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p000305b",
+                "ids": ",usp000305b,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.43,
+                    53.096,
+                    20
+                ]
+            },
+            "id": "usp000305b"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 535568998020,
+                "updated": 1415320770912,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003123",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003123&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0003123",
+                "ids": ",usp0003123,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "rock burst",
+                "title": "M 2.3 Rock Burst - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.161,
+                    55.857,
+                    1
+                ]
+            },
+            "id": "usp0003123"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 536014204270,
+                "updated": 1415320771448,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000315u",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000315u&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p000315u",
+                "ids": ",usp000315u,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.348,
+                    51.862,
+                    10
+                ]
+            },
+            "id": "usp000315u"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 546847789750,
+                "updated": 1415320819512,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00034mj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00034mj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p00034mj",
+                "ids": ",usp00034mj,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.863,
+                    52.54,
+                    10
+                ]
+            },
+            "id": "usp00034mj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 547080501340,
+                "updated": 1415320821247,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00034pn",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00034pn&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p00034pn",
+                "ids": ",usp00034pn,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.073,
+                    56.697,
+                    10
+                ]
+            },
+            "id": "usp00034pn"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "North Sea",
+                "time": 560312701870,
+                "updated": 1415320862595,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00038ym",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00038ym&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p00038ym",
+                "ids": ",usp00038ym,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.584,
+                    58.353,
+                    5
+                ]
+            },
+            "id": "usp00038ym"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 560867748410,
+                "updated": 1415320864647,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000394z",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000394z&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p000394z",
+                "ids": ",usp000394z,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.328,
+                    55.862,
+                    5
+                ]
+            },
+            "id": "usp000394z"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "Scotland, United Kingdom",
+                "time": 561519011010,
+                "updated": 1415320865643,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00039c2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00039c2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p00039c2",
+                "ids": ",usp00039c2,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.045,
+                    57.83,
+                    10
+                ]
+            },
+            "id": "usp00039c2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "United Kingdom",
+                "time": 563419993050,
+                "updated": 1415320872776,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00039zt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00039zt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p00039zt",
+                "ids": ",usp00039zt,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.83,
+                    54.183,
+                    10
+                ]
+            },
+            "id": "usp00039zt"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "Scotland, United Kingdom",
+                "time": 564376053600,
+                "updated": 1415320874556,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003a9j",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003a9j&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0003a9j",
+                "ids": ",usp0003a9j,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.455,
+                    56.651,
+                    10
+                ]
+            },
+            "id": "usp0003a9j"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 565698177680,
+                "updated": 1415320881087,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003aza",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003aza&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p0003aza",
+                "ids": ",usp0003aza,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.967,
+                    53.385,
+                    10
+                ]
+            },
+            "id": "usp0003aza"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "North Sea",
+                "time": 569777286580,
+                "updated": 1415320891818,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003c8k",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003c8k&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0003c8k",
+                "ids": ",usp0003c8k,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.439,
+                    58.435,
+                    10
+                ]
+            },
+            "id": "usp0003c8k"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "Scotland, United Kingdom",
+                "time": 571233712310,
+                "updated": 1415320898610,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003cu9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003cu9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0003cu9",
+                "ids": ",usp0003cu9,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.723,
+                    57.356,
+                    10
+                ]
+            },
+            "id": "usp0003cu9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "England, United Kingdom",
+                "time": 577792168160,
+                "updated": 1415320918749,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003f9p",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003f9p&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0003f9p",
+                "ids": ",usp0003f9p,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.869,
+                    54.964,
+                    10
+                ]
+            },
+            "id": "usp0003f9p"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "Scotland, United Kingdom",
+                "time": 580371214080,
+                "updated": 1415320931220,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003g9f",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003g9f&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p0003g9f",
+                "ids": ",usp0003g9f,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.458,
+                    56.62,
+                    10
+                ]
+            },
+            "id": "usp0003g9f"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 581979054170,
+                "updated": 1415320938903,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003gvm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003gvm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0003gvm",
+                "ids": ",usp0003gvm,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "explosion",
+                "title": "M 2.9 Explosion - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.337,
+                    51.749,
+                    0
+                ]
+            },
+            "id": "usp0003gvm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 590077386740,
+                "updated": 1415320968987,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003kxc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003kxc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p0003kxc",
+                "ids": ",usp0003kxc,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.592,
+                    54.336,
+                    10
+                ]
+            },
+            "id": "usp0003kxc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.1,
+                "place": "England, United Kingdom",
+                "time": 593578912290,
+                "updated": 1415320979138,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003n3n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003n3n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 148,
+                "net": "us",
+                "code": "p0003n3n",
+                "ids": ",usp0003n3n,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.1 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.444,
+                    51.404,
+                    10
+                ]
+            },
+            "id": "usp0003n3n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "North Sea",
+                "time": 607098626580,
+                "updated": 1415321031545,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0003td1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0003td1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0003td1",
+                "ids": ",usp0003td1,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "explosion",
+                "title": "M 3.2 Explosion - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.232,
+                    58.536,
+                    0
+                ]
+            },
+            "id": "usp0003td1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 631667713980,
+                "updated": 1415321129639,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00043z5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00043z5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p00043z5",
+                "ids": ",usp00043z5,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.383,
+                    55.925,
+                    10
+                ]
+            },
+            "id": "usp00043z5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "Scotland, United Kingdom",
+                "time": 631912858580,
+                "updated": 1415321131079,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0004423",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0004423&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0004423",
+                "ids": ",usp0004423,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.341,
+                    56.645,
+                    10
+                ]
+            },
+            "id": "usp0004423"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "Scotland, United Kingdom",
+                "time": 633361351580,
+                "updated": 1415321135688,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00044rv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00044rv&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p00044rv",
+                "ids": ",usp00044rv,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.277,
+                    56.09,
+                    10
+                ]
+            },
+            "id": "usp00044rv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "England, United Kingdom",
+                "time": 634442002650,
+                "updated": 1415321140742,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0004568",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0004568&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p0004568",
+                "ids": ",usp0004568,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "md",
+                "type": "earthquake",
+                "title": "M 3.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.159,
+                    53.138,
+                    10
+                ]
+            },
+            "id": "usp0004568"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 636509927180,
+                "updated": 1415321152081,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000465f",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000465f&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000465f",
+                "ids": ",usp000465f,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.994,
+                    52.828,
+                    10
+                ]
+            },
+            "id": "usp000465f"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.7,
+                "place": "England, United Kingdom",
+                "time": 639063991760,
+                "updated": 1598657424809,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00047ck",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00047ck&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": 5.37,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 340,
+                "net": "us",
+                "code": "p00047ck",
+                "ids": ",usp00047ck,atlas19900402134631,",
+                "sources": ",us,atlas,",
+                "types": ",impact-text,origin,phase-data,shakemap,trump-shakemap,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.3,
+                "gap": null,
+                "magType": "mb",
+                "type": "earthquake",
+                "title": "M 4.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.985,
+                    52.314,
+                    18
+                ]
+            },
+            "id": "usp00047ck"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "Wales, United Kingdom",
+                "time": 677051652910,
+                "updated": 1415321325373,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0004t0s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0004t0s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0004t0s",
+                "ids": ",usp0004t0s,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.21,
+                    52.309,
+                    10
+                ]
+            },
+            "id": "usp0004t0s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "England, United Kingdom",
+                "time": 677096983700,
+                "updated": 1415321325498,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0004t1k",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0004t1k&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0004t1k",
+                "ids": ",usp0004t1k,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.186,
+                    50.18,
+                    10
+                ]
+            },
+            "id": "usp0004t1k"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 691181858460,
+                "updated": 1415321377250,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0004zq3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0004zq3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0004zq3",
+                "ids": ",usp0004zq3,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.705,
+                    50.131,
+                    10
+                ]
+            },
+            "id": "usp0004zq3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.4,
+                "place": "England, United Kingdom",
+                "time": 698289749410,
+                "updated": 1415321406342,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000535d",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000535d&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 178,
+                "net": "us",
+                "code": "p000535d",
+                "ids": ",usp000535d,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.094,
+                    52.404,
+                    10
+                ]
+            },
+            "id": "usp000535d"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "France",
+                "time": 701382585440,
+                "updated": 1415321418458,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00054rb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00054rb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p00054rb",
+                "ids": ",usp00054rb,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.3,
+                    50.901,
+                    10
+                ]
+            },
+            "id": "usp00054rb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "Ireland",
+                "time": 704496845280,
+                "updated": 1415321430784,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00056my",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00056my&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p00056my",
+                "ids": ",usp00056my,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - Ireland"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.246,
+                    52.939,
+                    10
+                ]
+            },
+            "id": "usp00056my"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Scotland, United Kingdom",
+                "time": 712138612740,
+                "updated": 1415321467675,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005bgk",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005bgk&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0005bgk",
+                "ids": ",usp0005bgk,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.446,
+                    57.467,
+                    10
+                ]
+            },
+            "id": "usp0005bgk"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Wales, United Kingdom",
+                "time": 712433113150,
+                "updated": 1415321468442,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005bpx",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005bpx&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p0005bpx",
+                "ids": ",usp0005bpx,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.393,
+                    53.16,
+                    10
+                ]
+            },
+            "id": "usp0005bpx"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "Wales-England region, United Kingdom",
+                "time": 714012813590,
+                "updated": 1415321476612,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005ck2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005ck2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0005ck2",
+                "ids": ",usp0005ck2,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.124,
+                    51.598,
+                    10
+                ]
+            },
+            "id": "usp0005ck2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Scotland, United Kingdom",
+                "time": 714930718720,
+                "updated": 1415321479519,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005d5n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005d5n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p0005d5n",
+                "ids": ",usp0005d5n,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.042,
+                    56.061,
+                    10
+                ]
+            },
+            "id": "usp0005d5n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 717245275140,
+                "updated": 1415321490196,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005ec9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005ec9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0005ec9",
+                "ids": ",usp0005ec9,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.482,
+                    50.919,
+                    10
+                ]
+            },
+            "id": "usp0005ec9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 725730564830,
+                "updated": 1415321526399,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005k2v",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005k2v&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0005k2v",
+                "ids": ",usp0005k2v,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.436,
+                    56.388,
+                    10
+                ]
+            },
+            "id": "usp0005k2v"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "England, United Kingdom",
+                "time": 732077333750,
+                "updated": 1415321555348,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005pfu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005pfu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0005pfu",
+                "ids": ",usp0005pfu,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.595,
+                    54.378,
+                    5
+                ]
+            },
+            "id": "usp0005pfu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 732205409030,
+                "updated": 1415321555595,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005phz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005phz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0005phz",
+                "ids": ",usp0005phz,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.077,
+                    53.098,
+                    5
+                ]
+            },
+            "id": "usp0005phz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 734909402320,
+                "updated": 1415321569394,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005r87",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005r87&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0005r87",
+                "ids": ",usp0005r87,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.763,
+                    52.499,
+                    5
+                ]
+            },
+            "id": "usp0005r87"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "England, United Kingdom",
+                "time": 736525228460,
+                "updated": 1415321577436,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005s6t",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005s6t&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0005s6t",
+                "ids": ",usp0005s6t,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.356,
+                    52.366,
+                    5
+                ]
+            },
+            "id": "usp0005s6t"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 736779042410,
+                "updated": 1415321578515,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005scc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005scc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0005scc",
+                "ids": ",usp0005scc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.5,
+                    52.157,
+                    10
+                ]
+            },
+            "id": "usp0005scc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 741073337360,
+                "updated": 1415321599719,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005v6n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005v6n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0005v6n",
+                "ids": ",usp0005v6n,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.8,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.597,
+                    54.1,
+                    10
+                ]
+            },
+            "id": "usp0005v6n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "England, United Kingdom",
+                "time": 742112314620,
+                "updated": 1415321606170,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0005vt3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0005vt3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p0005vt3",
+                "ids": ",usp0005vt3,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.078,
+                    54.323,
+                    5
+                ]
+            },
+            "id": "usp0005vt3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 748229992350,
+                "updated": 1415321638689,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00060gc",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00060gc&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p00060gc",
+                "ids": ",usp00060gc,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.746,
+                    52.198,
+                    10
+                ]
+            },
+            "id": "usp00060gc"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "United Kingdom",
+                "time": 750332613320,
+                "updated": 1415321651650,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00061ta",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00061ta&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p00061ta",
+                "ids": ",usp00061ta,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.713,
+                    53.147,
+                    10
+                ]
+            },
+            "id": "usp00061ta"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 753040366350,
+                "updated": 1415321664235,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00063j2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00063j2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p00063j2",
+                "ids": ",usp00063j2,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.022,
+                    53.334,
+                    5
+                ]
+            },
+            "id": "usp00063j2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.6,
+                "place": "Wales-England region, United Kingdom",
+                "time": 757394245090,
+                "updated": 1415321681389,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00065wh",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00065wh&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 199,
+                "net": "us",
+                "code": "p00065wh",
+                "ids": ",usp00065wh,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.6 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.418,
+                    51.291,
+                    10
+                ]
+            },
+            "id": "usp00065wh"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 758061963570,
+                "updated": 1415321685000,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000666s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000666s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p000666s",
+                "ids": ",usp000666s,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.093,
+                    51.563,
+                    10
+                ]
+            },
+            "id": "usp000666s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "Wales, United Kingdom",
+                "time": 760857071670,
+                "updated": 1415321697842,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00068a7",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00068a7&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p00068a7",
+                "ids": ",usp00068a7,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.077,
+                    53.212,
+                    10
+                ]
+            },
+            "id": "usp00068a7"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.4,
+                "place": "England, United Kingdom",
+                "time": 761307357480,
+                "updated": 1415321699113,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00068hu",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00068hu&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 298,
+                "net": "us",
+                "code": "p00068hu",
+                "ids": ",usp00068hu,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.847,
+                    52.378,
+                    10
+                ]
+            },
+            "id": "usp00068hu"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 761311125150,
+                "updated": 1415321699122,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00068hv",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00068hv&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p00068hv",
+                "ids": ",usp00068hv,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.066,
+                    52.488,
+                    10
+                ]
+            },
+            "id": "usp00068hv"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Wales, United Kingdom",
+                "time": 763921314220,
+                "updated": 1415321709727,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00069tz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00069tz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p00069tz",
+                "ids": ",usp00069tz,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.367,
+                    52.536,
+                    10
+                ]
+            },
+            "id": "usp00069tz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.7,
+                "place": "England, United Kingdom",
+                "time": 768704887310,
+                "updated": 1415321728093,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006cea",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006cea&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 211,
+                "net": "us",
+                "code": "p0006cea",
+                "ids": ",usp0006cea,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.631,
+                    52.019,
+                    10
+                ]
+            },
+            "id": "usp0006cea"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "France",
+                "time": 769898199640,
+                "updated": 1415321731614,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006d4c",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006d4c&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006d4c",
+                "ids": ",usp0006d4c,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.035,
+                    50.674,
+                    10
+                ]
+            },
+            "id": "usp0006d4c"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Wales-England region, United Kingdom",
+                "time": 772323409770,
+                "updated": 1415321744246,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006eq4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006eq4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p0006eq4",
+                "ids": ",usp0006eq4,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.164,
+                    51.646,
+                    10
+                ]
+            },
+            "id": "usp0006eq4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Scotland, United Kingdom",
+                "time": 774148986210,
+                "updated": 1415321751951,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006fmy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006fmy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p0006fmy",
+                "ids": ",usp0006fmy,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.527,
+                    56.246,
+                    5
+                ]
+            },
+            "id": "usp0006fmy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 774534563020,
+                "updated": 1415321752760,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006fv3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006fv3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006fv3",
+                "ids": ",usp0006fv3,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.063,
+                    54.384,
+                    10
+                ]
+            },
+            "id": "usp0006fv3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.5,
+                "place": "England, United Kingdom",
+                "time": 776165075690,
+                "updated": 1415321760838,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006gm2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006gm2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 96,
+                "net": "us",
+                "code": "p0006gm2",
+                "ids": ",usp0006gm2,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.7,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.5 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.527,
+                    51.116,
+                    10
+                ]
+            },
+            "id": "usp0006gm2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "Scotland, United Kingdom",
+                "time": 777099445540,
+                "updated": 1415321764769,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006h1q",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006h1q&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0006h1q",
+                "ids": ",usp0006h1q,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.736,
+                    57.148,
+                    5
+                ]
+            },
+            "id": "usp0006h1q"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Wales-England region, United Kingdom",
+                "time": 777167448840,
+                "updated": 1415321764879,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006h2z",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006h2z&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0006h2z",
+                "ids": ",usp0006h2z,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.139,
+                    51.603,
+                    5
+                ]
+            },
+            "id": "usp0006h2z"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 782085015760,
+                "updated": 1415321790979,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006m2s",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006m2s&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006m2s",
+                "ids": ",usp0006m2s,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.755,
+                    56.786,
+                    10
+                ]
+            },
+            "id": "usp0006m2s"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 784073643120,
+                "updated": 1415321803252,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006n63",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006n63&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0006n63",
+                "ids": ",usp0006n63,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.189,
+                    52.27,
+                    5
+                ]
+            },
+            "id": "usp0006n63"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Ireland",
+                "time": 785383246970,
+                "updated": 1415321809483,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006nzm",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006nzm&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p0006nzm",
+                "ids": ",usp0006nzm,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Ireland"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -7.308,
+                    55.193,
+                    10
+                ]
+            },
+            "id": "usp0006nzm"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "England, United Kingdom",
+                "time": 785783429100,
+                "updated": 1415321810589,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006p7v",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006p7v&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p0006p7v",
+                "ids": ",usp0006p7v,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.185,
+                    53.114,
+                    5
+                ]
+            },
+            "id": "usp0006p7v"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 786665116480,
+                "updated": 1415321815232,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006pq9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006pq9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006pq9",
+                "ids": ",usp0006pq9,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.021,
+                    53.867,
+                    5
+                ]
+            },
+            "id": "usp0006pq9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 788977208880,
+                "updated": 1415321823871,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006qqy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006qqy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0006qqy",
+                "ids": ",usp0006qqy,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.543,
+                    52.337,
+                    10
+                ]
+            },
+            "id": "usp0006qqy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "North Sea",
+                "time": 791760365910,
+                "updated": 1415321836154,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006s9f",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006s9f&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0006s9f",
+                "ids": ",usp0006s9f,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.651,
+                    57.919,
+                    10
+                ]
+            },
+            "id": "usp0006s9f"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 791864669650,
+                "updated": 1415321836822,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006sbg",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006sbg&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006sbg",
+                "ids": ",usp0006sbg,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.706,
+                    56.128,
+                    5
+                ]
+            },
+            "id": "usp0006sbg"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 793245543540,
+                "updated": 1415321841162,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006t80",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006t80&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0006t80",
+                "ids": ",usp0006t80,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.6,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.112,
+                    52.969,
+                    5
+                ]
+            },
+            "id": "usp0006t80"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 793408524480,
+                "updated": 1415321841588,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006tb9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006tb9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006tb9",
+                "ids": ",usp0006tb9,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.204,
+                    53.028,
+                    10
+                ]
+            },
+            "id": "usp0006tb9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 793439491610,
+                "updated": 1415321841643,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006tbx",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006tbx&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0006tbx",
+                "ids": ",usp0006tbx,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.287,
+                    52.976,
+                    10
+                ]
+            },
+            "id": "usp0006tbx"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "England, United Kingdom",
+                "time": 793487703000,
+                "updated": 1415321841701,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006tck",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006tck&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0006tck",
+                "ids": ",usp0006tck,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.206,
+                    53.039,
+                    10
+                ]
+            },
+            "id": "usp0006tck"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 793621882030,
+                "updated": 1415321842545,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006tf4",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006tf4&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0006tf4",
+                "ids": ",usp0006tf4,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.195,
+                    53.011,
+                    10
+                ]
+            },
+            "id": "usp0006tf4"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.3,
+                "place": "United Kingdom",
+                "time": 794933053120,
+                "updated": 1415321849777,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006u2b",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006u2b&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 81,
+                "net": "us",
+                "code": "p0006u2b",
+                "ids": ",usp0006u2b,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.3 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.115,
+                    54.251,
+                    10
+                ]
+            },
+            "id": "usp0006u2b"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 795134707840,
+                "updated": 1415321850454,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0006u5j",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0006u5j&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p0006u5j",
+                "ids": ",usp0006u5j,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.954,
+                    51.43,
+                    10
+                ]
+            },
+            "id": "usp0006u5j"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Scotland, United Kingdom",
+                "time": 809603956730,
+                "updated": 1415321916211,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00072jz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00072jz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p00072jz",
+                "ids": ",usp00072jz,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.853,
+                    57.24,
+                    10
+                ]
+            },
+            "id": "usp00072jz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 810670821380,
+                "updated": 1415321922497,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000735b",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000735b&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p000735b",
+                "ids": ",usp000735b,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.881,
+                    50.772,
+                    10
+                ]
+            },
+            "id": "usp000735b"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Scotland, United Kingdom",
+                "time": 812680971490,
+                "updated": 1415321932444,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00074bz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00074bz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p00074bz",
+                "ids": ",usp00074bz,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.577,
+                    57.111,
+                    14.8
+                ]
+            },
+            "id": "usp00074bz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "England, United Kingdom",
+                "time": 813435638710,
+                "updated": 1415321936703,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00074zd",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00074zd&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p00074zd",
+                "ids": ",usp00074zd,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.4,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.25,
+                    53.091,
+                    5
+                ]
+            },
+            "id": "usp00074zd"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "England, United Kingdom",
+                "time": 815187321570,
+                "updated": 1415321944812,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000762v",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000762v&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p000762v",
+                "ids": ",usp000762v,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.055,
+                    53.869,
+                    10
+                ]
+            },
+            "id": "usp000762v"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "England, United Kingdom",
+                "time": 817678300120,
+                "updated": 1415321954700,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00077s1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00077s1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p00077s1",
+                "ids": ",usp00077s1,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.311,
+                    52.978,
+                    5
+                ]
+            },
+            "id": "usp00077s1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "England, United Kingdom",
+                "time": 818697558580,
+                "updated": 1415321965538,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00078ts",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00078ts&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p00078ts",
+                "ids": ",usp00078ts,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "rock burst",
+                "title": "M 1.9 Rock Burst - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.877,
+                    53.301,
+                    1
+                ]
+            },
+            "id": "usp00078ts"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "Scotland, United Kingdom",
+                "time": 818949604670,
+                "updated": 1415321966262,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00078zj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00078zj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p00078zj",
+                "ids": ",usp00078zj,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.72,
+                    56.137,
+                    5
+                ]
+            },
+            "id": "usp00078zj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "England, United Kingdom",
+                "time": 824851425590,
+                "updated": 1415321996696,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0007dk1",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0007dk1&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p0007dk1",
+                "ids": ",usp0007dk1,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.2,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.29,
+                    52.963,
+                    5
+                ]
+            },
+            "id": "usp0007dk1"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "England, United Kingdom",
+                "time": 826242082860,
+                "updated": 1415322004764,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0007ef6",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0007ef6&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 222,
+                "net": "us",
+                "code": "p0007ef6",
+                "ids": ",usp0007ef6,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.768,
+                    52.791,
+                    10
+                ]
+            },
+            "id": "usp0007ef6"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "England, United Kingdom",
+                "time": 831354568410,
+                "updated": 1415322025560,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0007h0c",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0007h0c&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0007h0c",
+                "ids": ",usp0007h0c,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.3,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.231,
+                    53.034,
+                    5
+                ]
+            },
+            "id": "usp0007h0c"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 835753961330,
+                "updated": 1415322040664,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0007k9h",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0007k9h&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0007k9h",
+                "ids": ",usp0007k9h,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.5,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.214,
+                    55.333,
+                    10
+                ]
+            },
+            "id": "usp0007k9h"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "France",
+                "time": 855844303300,
+                "updated": 1415322128813,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0007x6f",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0007x6f&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0007x6f",
+                "ids": ",usp0007x6f,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.99,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.216,
+                    50.518,
+                    5
+                ]
+            },
+            "id": "usp0007x6f"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.6,
+                "place": "England, United Kingdom",
+                "time": 862424578490,
+                "updated": 1415322159480,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00081he",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00081he&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 104,
+                "net": "us",
+                "code": "p00081he",
+                "ids": ",usp00081he,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.93,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.039,
+                    51.358,
+                    5
+                ]
+            },
+            "id": "usp00081he"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "France",
+                "time": 862454183300,
+                "updated": 1415322161501,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00081j2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00081j2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p00081j2",
+                "ids": ",usp00081j2,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.89,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.253,
+                    50.33,
+                    5
+                ]
+            },
+            "id": "usp00081j2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 876961148240,
+                "updated": 1415322222460,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008959",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008959&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0008959",
+                "ids": ",usp0008959,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.72,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.471,
+                    50.484,
+                    10
+                ]
+            },
+            "id": "usp0008959"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Scotland, United Kingdom",
+                "time": 880851563570,
+                "updated": 1415322238599,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008bhr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008bhr&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p0008bhr",
+                "ids": ",usp0008bhr,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.51,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.128,
+                    56.164,
+                    10
+                ]
+            },
+            "id": "usp0008bhr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.8,
+                "place": "France",
+                "time": 885890174600,
+                "updated": 1415322263267,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008f1f",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008f1f&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 222,
+                "net": "us",
+                "code": "p0008f1f",
+                "ids": ",usp0008f1f,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.8 - France"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.2,
+                    50.5,
+                    2
+                ]
+            },
+            "id": "usp0008f1f"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 887229557210,
+                "updated": 1415322272111,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008fug",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008fug&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0008fug",
+                "ids": ",usp0008fug,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.69,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.948,
+                    51.564,
+                    10
+                ]
+            },
+            "id": "usp0008fug"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "England, United Kingdom",
+                "time": 888626579200,
+                "updated": 1415322275894,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008gq6",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008gq6&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p0008gq6",
+                "ids": ",usp0008gq6,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.264,
+                    52.952,
+                    1.6
+                ]
+            },
+            "id": "usp0008gq6"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Scotland, United Kingdom",
+                "time": 889236539500,
+                "updated": 1415322282365,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008h2u",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008h2u&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p0008h2u",
+                "ids": ",usp0008h2u,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.26,
+                    56.41,
+                    9.4
+                ]
+            },
+            "id": "usp0008h2u"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 890654423240,
+                "updated": 1415322289089,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008hwj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008hwj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0008hwj",
+                "ids": ",usp0008hwj,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.07,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.666,
+                    50.606,
+                    5
+                ]
+            },
+            "id": "usp0008hwj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 890945524500,
+                "updated": 1415322290463,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008j33",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008j33&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0008j33",
+                "ids": ",usp0008j33,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.75,
+                    56.25,
+                    5.2
+                ]
+            },
+            "id": "usp0008j33"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "Scotland, United Kingdom",
+                "time": 894161566900,
+                "updated": 1415322309380,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008mbs",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008mbs&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p0008mbs",
+                "ids": ",usp0008mbs,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.04,
+                    56.06,
+                    15.1
+                ]
+            },
+            "id": "usp0008mbs"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "England, United Kingdom",
+                "time": 894388904700,
+                "updated": 1415322310700,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008mh9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008mh9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p0008mh9",
+                "ids": ",usp0008mh9,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.26,
+                    53.56,
+                    0.5
+                ]
+            },
+            "id": "usp0008mh9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "England, United Kingdom",
+                "time": 895798684500,
+                "updated": 1415322314887,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008nh3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008nh3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p0008nh3",
+                "ids": ",usp0008nh3,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.118,
+                    53.243,
+                    2.7
+                ]
+            },
+            "id": "usp0008nh3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.8,
+                "place": "Bristol Channel region, United Kingdom",
+                "time": 896619352500,
+                "updated": 1415322317404,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008p33",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008p33&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 121,
+                "net": "us",
+                "code": "p0008p33",
+                "ids": ",usp0008p33,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.8 - Bristol Channel region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.71,
+                    51.19,
+                    14.7
+                ]
+            },
+            "id": "usp0008p33"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Bristol Channel region, United Kingdom",
+                "time": 896619811700,
+                "updated": 1415322317407,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008p34",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008p34&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p0008p34",
+                "ids": ",usp0008p34,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Bristol Channel region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.689,
+                    51.206,
+                    8.7
+                ]
+            },
+            "id": "usp0008p34"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.5,
+                "place": "North Sea",
+                "time": 898457018900,
+                "updated": 1415322326074,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008q8n",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008q8n&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 188,
+                "net": "us",
+                "code": "p0008q8n",
+                "ids": ",usp0008q8n,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.5 - North Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1.01,
+                    54.07,
+                    24.9
+                ]
+            },
+            "id": "usp0008q8n"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.9,
+                "place": "England, United Kingdom",
+                "time": 898742873500,
+                "updated": 1415322326922,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008qes",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008qes&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 56,
+                "net": "us",
+                "code": "p0008qes",
+                "ids": ",usp0008qes,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.2,
+                    53.45,
+                    1.1
+                ]
+            },
+            "id": "usp0008qes"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "England, United Kingdom",
+                "time": 898804922200,
+                "updated": 1415322327052,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008qfy",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008qfy&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p0008qfy",
+                "ids": ",usp0008qfy,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.168,
+                    53.411,
+                    0.6
+                ]
+            },
+            "id": "usp0008qfy"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.4,
+                "place": "United Kingdom",
+                "time": 900920307040,
+                "updated": 1415322337396,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008rx2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008rx2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 89,
+                "net": "us",
+                "code": "p0008rx2",
+                "ids": ",usp0008rx2,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.4 - United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -6.467,
+                    55.567,
+                    13.2
+                ]
+            },
+            "id": "usp0008rx2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Scotland, United Kingdom",
+                "time": 901005421400,
+                "updated": 1415322337507,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008rye",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008rye&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p0008rye",
+                "ids": ",usp0008rye,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.63,
+                    55.1,
+                    12.3
+                ]
+            },
+            "id": "usp0008rye"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.4,
+                "place": "Scotland, United Kingdom",
+                "time": 901152951300,
+                "updated": 1415322337791,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008s12",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008s12&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 30,
+                "net": "us",
+                "code": "p0008s12",
+                "ids": ",usp0008s12,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.62,
+                    55.09,
+                    8.2
+                ]
+            },
+            "id": "usp0008s12"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.6,
+                "place": "Scotland, United Kingdom",
+                "time": 901229894600,
+                "updated": 1415322337929,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008s2m",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008s2m&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 39,
+                "net": "us",
+                "code": "p0008s2m",
+                "ids": ",usp0008s2m,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.6 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.71,
+                    56.15,
+                    1
+                ]
+            },
+            "id": "usp0008s2m"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "England, United Kingdom",
+                "time": 901882566800,
+                "updated": 1415322339837,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008shj",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008shj&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p0008shj",
+                "ids": ",usp0008shj,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.38,
+                    53.34,
+                    8.7
+                ]
+            },
+            "id": "usp0008shj"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2,
+                "place": "Irish Sea",
+                "time": 904566194500,
+                "updated": 1415322355471,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008u5t",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008u5t&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 62,
+                "net": "us",
+                "code": "p0008u5t",
+                "ids": ",usp0008u5t,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.0 - Irish Sea"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.309,
+                    53.028,
+                    12.6
+                ]
+            },
+            "id": "usp0008u5t"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.8,
+                "place": "Scotland, United Kingdom",
+                "time": 904761207800,
+                "updated": 1415322359060,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008u9x",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008u9x&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 50,
+                "net": "us",
+                "code": "p0008u9x",
+                "ids": ",usp0008u9x,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.8 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.71,
+                    56.14,
+                    2.3
+                ]
+            },
+            "id": "usp0008u9x"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.1,
+                "place": "Scotland, United Kingdom",
+                "time": 905826786900,
+                "updated": 1415322363439,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008uyb",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008uyb&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 68,
+                "net": "us",
+                "code": "p0008uyb",
+                "ids": ",usp0008uyb,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.1 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.95,
+                    55.56,
+                    15.4
+                ]
+            },
+            "id": "usp0008uyb"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.5,
+                "place": "Scotland, United Kingdom",
+                "time": 906641909800,
+                "updated": 1415322365824,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008vf9",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008vf9&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 35,
+                "net": "us",
+                "code": "p0008vf9",
+                "ids": ",usp0008vf9,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.5 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.463,
+                    56.922,
+                    7.3
+                ]
+            },
+            "id": "usp0008vf9"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.2,
+                "place": "Scotland, United Kingdom",
+                "time": 906894237600,
+                "updated": 1415322366519,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008vkr",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008vkr&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 22,
+                "net": "us",
+                "code": "p0008vkr",
+                "ids": ",usp0008vkr,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.098,
+                    56.193,
+                    3.8
+                ]
+            },
+            "id": "usp0008vkr"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.8,
+                "place": "England, United Kingdom",
+                "time": 907000176600,
+                "updated": 1415322366797,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008vns",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008vns&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 50,
+                "net": "us",
+                "code": "p0008vns",
+                "ids": ",usp0008vns,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.8 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.806,
+                    52.547,
+                    11.9
+                ]
+            },
+            "id": "usp0008vns"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.1,
+                "place": "Scotland, United Kingdom",
+                "time": 907008889400,
+                "updated": 1415322366815,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008vnz",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008vnz&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 19,
+                "net": "us",
+                "code": "p0008vnz",
+                "ids": ",usp0008vnz,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.1 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.497,
+                    57.45,
+                    7.5
+                ]
+            },
+            "id": "usp0008vnz"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.1,
+                "place": "England, United Kingdom",
+                "time": 907785582800,
+                "updated": 1415322372800,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008w54",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008w54&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 148,
+                "net": "us",
+                "code": "p0008w54",
+                "ids": ",usp0008w54,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.1 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -0.29,
+                    53.6,
+                    30.7
+                ]
+            },
+            "id": "usp0008w54"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.7,
+                "place": "Wales, United Kingdom",
+                "time": 908543091100,
+                "updated": 1415322375593,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008wky",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008wky&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 112,
+                "net": "us",
+                "code": "p0008wky",
+                "ids": ",usp0008wky,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.7 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.23,
+                    53.18,
+                    11.9
+                ]
+            },
+            "id": "usp0008wky"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.8,
+                "place": "Bristol Channel region, United Kingdom",
+                "time": 909725270700,
+                "updated": 1415322378567,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0008x9e",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0008x9e&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 50,
+                "net": "us",
+                "code": "p0008x9e",
+                "ids": ",usp0008x9e,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.8 - Bristol Channel region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.491,
+                    51.827,
+                    11.8
+                ]
+            },
+            "id": "usp0008x9e"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "England, United Kingdom",
+                "time": 916917013600,
+                "updated": 1415322410235,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00091f3",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00091f3&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p00091f3",
+                "ids": ",usp00091f3,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.86,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.165,
+                    53.042,
+                    10
+                ]
+            },
+            "id": "usp00091f3"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Ireland",
+                "time": 925433494100,
+                "updated": 1415322451805,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp000972p",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp000972p&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p000972p",
+                "ids": ",usp000972p,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Ireland"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -7.37,
+                    55.07,
+                    8.8
+                ]
+            },
+            "id": "usp000972p"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.2,
+                "place": "Scotland, United Kingdom",
+                "time": 927978574500,
+                "updated": 1415322464636,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp00098z2",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp00098z2&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 74,
+                "net": "us",
+                "code": "p00098z2",
+                "ids": ",usp00098z2,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.2 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.85,
+                    57.25,
+                    5.6
+                ]
+            },
+            "id": "usp00098z2"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3,
+                "place": "England, United Kingdom",
+                "time": 929586021150,
+                "updated": 1415322474444,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009a0x",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009a0x&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 138,
+                "net": "us",
+                "code": "p0009a0x",
+                "ids": ",usp0009a0x,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.18,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.0 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.511,
+                    51.97,
+                    10
+                ]
+            },
+            "id": "usp0009a0x"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.7,
+                "place": "Scotland, United Kingdom",
+                "time": 930406269600,
+                "updated": 1415322477321,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009aka",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009aka&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 44,
+                "net": "us",
+                "code": "p0009aka",
+                "ids": ",usp0009aka,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.7 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -5.085,
+                    57.716,
+                    7.8
+                ]
+            },
+            "id": "usp0009aka"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "England, United Kingdom",
+                "time": 930704201800,
+                "updated": 1415322478130,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009ate",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009ate&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p0009ate",
+                "ids": ",usp0009ate,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -1.336,
+                    53.441,
+                    1
+                ]
+            },
+            "id": "usp0009ate"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "Wales-England region, United Kingdom",
+                "time": 933327072300,
+                "updated": 1415322488965,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009ca8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009ca8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0009ca8",
+                "ids": ",usp0009ca8,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.201,
+                    51.689,
+                    6.4
+                ]
+            },
+            "id": "usp0009ca8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.3,
+                "place": "Wales-England region, United Kingdom",
+                "time": 933374597800,
+                "updated": 1415322489177,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009cb5",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009cb5&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 26,
+                "net": "us",
+                "code": "p0009cb5",
+                "ids": ",usp0009cb5,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.3 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.188,
+                    51.691,
+                    6.5
+                ]
+            },
+            "id": "usp0009cb5"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.4,
+                "place": "Scotland, United Kingdom",
+                "time": 933390910900,
+                "updated": 1415322489197,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009cbe",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009cbe&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 30,
+                "net": "us",
+                "code": "p0009cbe",
+                "ids": ",usp0009cbe,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.4 - Scotland, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.694,
+                    56.142,
+                    0.4
+                ]
+            },
+            "id": "usp0009cbe"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 1.1,
+                "place": "Wales-England region, United Kingdom",
+                "time": 933406428300,
+                "updated": 1415322489239,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009cbw",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009cbw&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 19,
+                "net": "us",
+                "code": "p0009cbw",
+                "ids": ",usp0009cbw,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 1.1 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.222,
+                    51.699,
+                    2.1
+                ]
+            },
+            "id": "usp0009cbw"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.3,
+                "place": "Wales, United Kingdom",
+                "time": 936162050340,
+                "updated": 1415322503393,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009dwn",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009dwn&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 168,
+                "net": "us",
+                "code": "p0009dwn",
+                "ids": ",usp0009dwn,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.12,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.3 - Wales, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.009,
+                    53.22,
+                    10
+                ]
+            },
+            "id": "usp0009dwn"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 2.9,
+                "place": "England, United Kingdom",
+                "time": 936569336190,
+                "updated": 1415322506510,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009e26",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009e26&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 129,
+                "net": "us",
+                "code": "p0009e26",
+                "ids": ",usp0009e26,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.22,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 2.9 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.957,
+                    50.175,
+                    5
+                ]
+            },
+            "id": "usp0009e26"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 3.2,
+                "place": "England, United Kingdom",
+                "time": 938836243420,
+                "updated": 1415322518528,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009faf",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009faf&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 158,
+                "net": "us",
+                "code": "p0009faf",
+                "ids": ",usp0009faf,",
+                "sources": ",us,",
+                "types": ",impact-text,origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": 0.79,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 3.2 - England, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.024,
+                    52.937,
+                    10
+                ]
+            },
+            "id": "usp0009faf"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.6,
+                "place": "English Channel",
+                "time": 939227206430,
+                "updated": 1415322520528,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009fh8",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009fh8&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": null,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 326,
+                "net": "us",
+                "code": "p0009fh8",
+                "ids": ",usp0009fh8,",
+                "sources": ",us,",
+                "types": ",origin,phase-data,",
+                "nst": null,
+                "dmin": null,
+                "rms": null,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.6 - English Channel"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0.27,
+                    50.06,
+                    1
+                ]
+            },
+            "id": "usp0009fh8"
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "mag": 4.5,
+                "place": "Wales-England region, United Kingdom",
+                "time": 940878917360,
+                "updated": 1587060999430,
+                "tz": null,
+                "url": "https://earthquake.usgs.gov/earthquakes/eventpage/usp0009gkt",
+                "detail": "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=usp0009gkt&format=geojson",
+                "felt": null,
+                "cdi": null,
+                "mmi": 4.8,
+                "alert": null,
+                "status": "reviewed",
+                "tsunami": 0,
+                "sig": 312,
+                "net": "us",
+                "code": "p0009gkt",
+                "ids": ",usp0009gkt,atlas19991025191517,",
+                "sources": ",us,atlas,",
+                "types": ",impact-text,origin,phase-data,shakemap,",
+                "nst": null,
+                "dmin": null,
+                "rms": 1.08,
+                "gap": null,
+                "magType": "ml",
+                "type": "earthquake",
+                "title": "M 4.5 - Wales-England region, United Kingdom"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -3.54,
+                    51.836,
+                    10
+                ]
+            },
+            "id": "usp0009gkt"
+        },
         {
             "type": "Feature",
             "properties": {
@@ -4811,11 +13251,11 @@
         }
     ],
     "bbox": [
-        -6.04,
+        -7.37,
         50.048,
         0,
-        1.582,
-        58.204,
-        28.7
+        1.584,
+        58.536,
+        33
     ]
 }

--- a/week04/quakes_plot.py
+++ b/week04/quakes_plot.py
@@ -1,0 +1,38 @@
+import json
+import requests
+import datetime
+import time
+import matplotlib.pyplot as plt
+import numpy as np
+
+if __name__ == "__main__":
+
+    quakes = requests.get("http://earthquake.usgs.gov/fdsnws/event/1/query.geojson",
+                      params={
+                          'starttime': "2000-01-01", 
+                          "maxlatitude": "58.723",
+                          "minlatitude": "50.008",
+                          "maxlongitude": "1.67",
+                          "minlongitude": "-9.756",
+                          "minmagnitude": "1",
+                          "endtime":"2018-10-11",
+                          "orderby": "time-asc"}
+                      )
+    print(quakes.text[0:100])
+
+
+    json_data = json.loads(quakes.text)
+    quake_data = json_data['features']
+
+    
+    years = []
+    year_list = range(2000,2019)
+    for year_val in year_list:
+        years.append(1000*time.mktime(datetime.datetime.strptime(str(year_val)+"-01-01", "%Y-%m-%d").timetuple()))
+    
+    quake_time =  [quake['properties']['time'] for quake in quake_data]
+
+
+    plt.figure()
+    plt.hist(quake_time, years)
+    plt.show()


### PR DESCRIPTION
The maximum magnitude earthquake in the past century is a 5.0 and occurred at the coordinates [-4.198, 52.878, 12.9]

Answers UCL-RITS/rse-classwork-2020#12