### PR TITLE
Week10 - Measuring performance and using numpy

### DIFF
--- a/week10/calc_pi_np.py
+++ b/week10/calc_pi_np.py
@@ -60,7 +60,7 @@ def command():
     result = timeit.repeat(calc_pi, number=arguments.number, repeat=arguments.repeat)
     
     best = min(result) / arguments.number
-    print(f"{arguments.number} loops, best of {arguments.repeat}: {format_time(best)} per loop")
+    #print(f"{arguments.number} loops, best of {arguments.repeat}: {format_time(best)} per loop")
 
 
 if __name__ == '__main__':

--- a/week10/calc_pi_np.py
+++ b/week10/calc_pi_np.py
@@ -1,0 +1,67 @@
+import argparse
+import math
+import random
+import timeit
+import numpy as np
+
+from utils import format_time
+
+def point_in_circle(coords, radius=1): 
+    """
+    Checks whether a point (x, y) is part of a circle with a set radius.
+
+    example
+    -------
+    >>> point_in_circle(0, 0)
+    True
+
+    """
+ 
+    r = np.sqrt(np.square(coords).sum(axis=1))
+    
+    return r[r<radius]
+
+def calculate_pi_timeit(points):
+    """
+    Wrapper function to build calculate_pi with a particular number of points
+    and returns the function to be timed.
+    """
+    def calculate_pi(): 
+        """
+        Calculates an approximated value of pi by the Monte Carlo method.
+        """
+        
+        coords = np.random.rand(points,2)
+        
+        within_circle = point_in_circle(coords)
+        
+        return 4 * len(within_circle)/points
+        
+    return calculate_pi
+
+
+def command():
+    """
+    entry point of the script to accept arguments
+    """
+
+    parser = argparse.ArgumentParser(description="Calculates an approximate value of PI and how long it takes",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+                                     
+    parser.add_argument('--npoints', '-np', default=10_000, type=int, help="Number of random points to use")
+    parser.add_argument('--number', '-n', default=100, type=int, help="Number of times to execute the calculations")
+    parser.add_argument('--repeat', '-r', default=5, type=int, help="How many times to repeat the timer")
+
+    arguments = parser.parse_args()
+
+    calc_pi = calculate_pi_timeit(arguments.npoints)
+    print(f"pi = {calc_pi()} (with {arguments.npoints})")
+    
+    result = timeit.repeat(calc_pi, number=arguments.number, repeat=arguments.repeat)
+    
+    best = min(result) / arguments.number
+    print(f"{arguments.number} loops, best of {arguments.repeat}: {format_time(best)} per loop")
+
+
+if __name__ == '__main__':
+    command()


### PR DESCRIPTION
**Original code**

$ python -m timeit -n 100 -r 5 -s "from calc_pi import calculate_pi_timeit" "calculate_pi_timeit(10_000)()"
100 loops, best of 5: 14.3 msec per loop

**Updated code (using numpy)**

$ python -m timeit -n 100 -r 5 -s "from calc_pi_np import calculate_pi_timeit" "calculate_pi_timeit(10_000)()"
100 loops, best of 5: 883 usec per loop

Numpy version is much faster but for whatever reason line 63 gives me an error in the numpy version so I had to comment it out

Measuring performance and using numpy #185